### PR TITLE
Implement organizer dashboard and management suite (Developer 4 tasks)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -475,11 +475,11 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 ### Priority 1: Dashboard Overview
 
 #### ORG-001: Dashboard Home Page
-- [ ] Welcome message with organizer name
-- [ ] Quick stats cards (total events, tickets sold, revenue)
-- [ ] Upcoming events list
-- [ ] Recent orders
-- [ ] Quick action buttons
+- [x] Welcome message with organizer name
+- [x] Quick stats cards (total events, tickets sold, revenue)
+- [x] Upcoming events list
+- [x] Recent orders
+- [x] Quick action buttons
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/page.tsx`
@@ -488,10 +488,10 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 - `src/components/dashboard/RecentOrders.tsx`
 
 #### ORG-002: Statistics API
-- [ ] Create `GET /api/events/[id]/statistics` endpoint
-- [ ] Return: tickets by type, revenue, order counts
-- [ ] Create `GET /api/dashboard/statistics` endpoint
-- [ ] Return: aggregate stats across all organizer events
+- [x] Create `GET /api/events/[id]/statistics` endpoint
+- [x] Return: tickets by type, revenue, order counts
+- [x] Create `GET /api/dashboard/statistics` endpoint
+- [x] Return: aggregate stats across all organizer events
 
 **Files to create:**
 - `src/app/api/events/[id]/statistics/route.ts`
@@ -500,11 +500,11 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 ### Priority 2: Event Management List
 
 #### ORG-003: Events List Page
-- [ ] List all organizer's events
-- [ ] Filter by status (draft, published, completed, cancelled)
-- [ ] Search by title
-- [ ] Quick actions (edit, view, publish, cancel)
-- [ ] Create new event button
+- [x] List all organizer's events
+- [x] Filter by status (draft, published, completed, cancelled)
+- [x] Search by title
+- [x] Quick actions (edit, view, publish, cancel)
+- [x] Create new event button
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/page.tsx`
@@ -512,12 +512,12 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 - `src/components/dashboard/EventStatusBadge.tsx`
 
 #### ORG-004: Event Detail Dashboard
-- [ ] Event overview with key stats
-- [ ] Ticket sales breakdown
-- [ ] Revenue chart
-- [ ] Recent orders for this event
-- [ ] Edit event button
-- [ ] Manage tickets button
+- [x] Event overview with key stats
+- [x] Ticket sales breakdown
+- [x] Revenue chart
+- [x] Recent orders for this event
+- [x] Edit event button
+- [x] Manage tickets button
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/[id]/page.tsx`
@@ -527,11 +527,11 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 ### Priority 3: Ticket & Discount Management UI
 
 #### ORG-005: Ticket Types Management Page
-- [ ] List ticket types for event
-- [ ] Create new ticket type form
-- [ ] Edit ticket type inline or modal
-- [ ] Delete with confirmation
-- [ ] Capacity and sales display
+- [x] List ticket types for event
+- [x] Create new ticket type form
+- [x] Edit ticket type inline or modal
+- [x] Delete with confirmation
+- [x] Capacity and sales display
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/[id]/tickets/page.tsx`
@@ -539,11 +539,11 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 - `src/components/dashboard/TicketTypeForm.tsx`
 
 #### ORG-006: Discount Codes Management Page
-- [ ] List discount codes for event
-- [ ] Create new discount code form
-- [ ] Edit discount code
-- [ ] Deactivate/delete codes
-- [ ] Usage statistics
+- [x] List discount codes for event
+- [x] Create new discount code form
+- [x] Edit discount code
+- [x] Deactivate/delete codes
+- [x] Usage statistics
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/[id]/discounts/page.tsx`
@@ -553,11 +553,11 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 ### Priority 4: Order Management
 
 #### ORG-007: Event Orders List
-- [ ] List all orders for an event
-- [ ] Filter by status, payment method, date
-- [ ] Search by buyer name/email
-- [ ] Export to CSV
-- [ ] Bulk actions
+- [x] List all orders for an event
+- [x] Filter by status, payment method, date
+- [x] Search by buyer name/email
+- [x] Export to CSV
+- [x] Bulk actions
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/[id]/orders/page.tsx`
@@ -565,12 +565,12 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 - `src/components/dashboard/OrderFilters.tsx`
 
 #### ORG-008: Order Detail View
-- [ ] Full order details
-- [ ] Buyer information
-- [ ] Ticket list
-- [ ] Payment information
-- [ ] Refund button (if applicable)
-- [ ] Send email to buyer
+- [x] Full order details
+- [x] Buyer information
+- [x] Ticket list
+- [x] Payment information
+- [x] Refund button (if applicable)
+- [x] Send email to buyer
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx`
@@ -579,20 +579,20 @@ Note: Implemented currently as `GET /api/events/[id]` with slug lookup in
 ### Priority 5: Settings & Profile
 
 #### ORG-009: Organizer Profile Settings
-- [ ] Edit organization name
-- [ ] Update logo
-- [ ] Website and social links
-- [ ] Description
+- [x] Edit organization name
+- [x] Update logo
+- [x] Website and social links
+- [x] Description
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/settings/page.tsx`
 - `src/components/dashboard/OrganizerProfileForm.tsx`
 
 #### ORG-010: Account Settings
-- [ ] Change password
-- [ ] Update email
-- [ ] Connected accounts (OAuth)
-- [ ] Delete account (with confirmation)
+- [x] Change password
+- [x] Update email
+- [x] Connected accounts (OAuth)
+- [x] Delete account (with confirmation)
 
 **Files to create:**
 - `src/app/(dashboard)/dashboard/settings/account/page.tsx`

--- a/src/app/(dashboard)/dashboard/events/[id]/discounts/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/discounts/page.tsx
@@ -1,0 +1,202 @@
+import { revalidatePath } from 'next/cache'
+import { notFound } from 'next/navigation'
+import { DiscountType, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { DiscountCodeForm } from '@/components/dashboard/DiscountCodeForm'
+import { DiscountCodeList } from '@/components/dashboard/DiscountCodeList'
+
+type PageProps = {
+  params: Promise<{ id: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export default async function DiscountCodesPage({ params, searchParams }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const { id } = await params
+  const qs = await searchParams
+  const editId = readParam(qs.edit)
+
+  const event = await prisma.event.findFirst({
+    where: {
+      id,
+      organizerId: organizerProfile.id,
+    },
+    select: {
+      id: true,
+      title: true,
+      discountCodes: {
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          code: true,
+          discountType: true,
+          discountValue: true,
+          maxUses: true,
+          usedCount: true,
+          isActive: true,
+        },
+      },
+    },
+  })
+
+  if (!event) {
+    notFound()
+  }
+
+  async function createDiscountCode(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+
+    const eventCheck = await prisma.event.findFirst({
+      where: { id, organizerId: profile.id },
+      select: { id: true },
+    })
+
+    if (!eventCheck) {
+      throw new Error('Event not found')
+    }
+
+    const code = String(formData.get('code') || '').trim().toUpperCase()
+    const discountType = String(formData.get('discountType') || 'PERCENTAGE') as DiscountType
+    const discountValue = new Prisma.Decimal(String(formData.get('discountValue') || '0'))
+    const maxUsesRaw = String(formData.get('maxUses') || '').trim()
+    const maxUses = maxUsesRaw ? Number(maxUsesRaw) : null
+    const isActive = String(formData.get('isActive') || 'true') === 'true'
+
+    await prisma.discountCode.create({
+      data: {
+        eventId: eventCheck.id,
+        code,
+        discountType,
+        discountValue,
+        maxUses,
+        isActive,
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/discounts`)
+  }
+
+  async function updateDiscountCode(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const discountCodeId = String(formData.get('discountCodeId') || '')
+    if (!discountCodeId) return
+
+    const existing = await prisma.discountCode.findFirst({
+      where: {
+        id: discountCodeId,
+        event: {
+          id,
+          organizerId: profile.id,
+        },
+      },
+      select: { id: true },
+    })
+
+    if (!existing) {
+      throw new Error('Discount code not found')
+    }
+
+    const code = String(formData.get('code') || '').trim().toUpperCase()
+    const discountType = String(formData.get('discountType') || 'PERCENTAGE') as DiscountType
+    const discountValue = new Prisma.Decimal(String(formData.get('discountValue') || '0'))
+    const maxUsesRaw = String(formData.get('maxUses') || '').trim()
+    const maxUses = maxUsesRaw ? Number(maxUsesRaw) : null
+    const isActive = String(formData.get('isActive') || 'true') === 'true'
+
+    await prisma.discountCode.update({
+      where: { id: existing.id },
+      data: {
+        code,
+        discountType,
+        discountValue,
+        maxUses,
+        isActive,
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/discounts`)
+  }
+
+  async function deleteDiscountCode(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const discountCodeId = String(formData.get('discountCodeId') || '')
+
+    const existing = await prisma.discountCode.findFirst({
+      where: {
+        id: discountCodeId,
+        event: {
+          id,
+          organizerId: profile.id,
+        },
+      },
+      select: { id: true },
+    })
+
+    if (!existing) return
+
+    await prisma.discountCode.delete({
+      where: { id: existing.id },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/discounts`)
+  }
+
+  const editableDiscountCode = editId ? event.discountCodes.find((code) => code.id === editId) : undefined
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Discount Codes</h1>
+        <p className="text-gray-600">Manage discounts and usage limits for {event.title}.</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <DiscountCodeForm title="Create Discount Code" submitLabel="Create Discount Code" action={createDiscountCode} />
+        <DiscountCodeForm
+          title="Edit Discount Code"
+          submitLabel="Update Discount Code"
+          action={updateDiscountCode}
+          initial={
+            editableDiscountCode
+              ? {
+                  id: editableDiscountCode.id,
+                  code: editableDiscountCode.code,
+                  discountType: editableDiscountCode.discountType,
+                  discountValue: Number(editableDiscountCode.discountValue.toString()),
+                  maxUses: editableDiscountCode.maxUses,
+                  isActive: editableDiscountCode.isActive,
+                }
+              : undefined
+          }
+        />
+      </div>
+
+      <DiscountCodeList
+        discountCodes={event.discountCodes.map((discountCode) => ({
+          id: discountCode.id,
+          code: discountCode.code,
+          discountType: discountCode.discountType,
+          discountValue: Number(discountCode.discountValue.toString()),
+          usedCount: discountCode.usedCount,
+          maxUses: discountCode.maxUses,
+          isActive: discountCode.isActive,
+        }))}
+        deleteAction={deleteDiscountCode}
+      />
+
+      <p className="text-xs text-gray-500">Tip: add <code>?edit=discountCodeId</code> to the URL to prefill the edit form for a specific code.</p>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
@@ -1,0 +1,143 @@
+import { revalidatePath } from 'next/cache'
+import { notFound } from 'next/navigation'
+import { prisma } from '@/lib/db'
+import { sendOrderConfirmationEmail } from '@/lib/email'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { OrderDetailView } from '@/components/dashboard/OrderDetailView'
+
+type PageProps = {
+  params: Promise<{ id: string; orderId: string }>
+}
+
+export default async function EventOrderDetailPage({ params }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const { id, orderId } = await params
+
+  const order = await prisma.order.findFirst({
+    where: {
+      id: orderId,
+      eventId: id,
+      event: {
+        organizerId: organizerProfile.id,
+      },
+    },
+    include: {
+      items: {
+        include: {
+          ticketType: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!order) {
+    notFound()
+  }
+
+  async function refundAction(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const submittedOrderId = String(formData.get('orderId') || '')
+
+    const targetOrder = await prisma.order.findFirst({
+      where: {
+        id: submittedOrderId,
+        eventId: id,
+        event: {
+          organizerId: profile.id,
+        },
+      },
+      select: {
+        id: true,
+        status: true,
+      },
+    })
+
+    if (!targetOrder) {
+      throw new Error('Order not found')
+    }
+
+    await prisma.order.update({
+      where: { id: targetOrder.id },
+      data: {
+        refundStatus: 'PENDING',
+        refundReason: 'Manual organizer refund request',
+        refundNotes: `Marked pending from dashboard on ${new Date().toISOString()}`,
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/orders/${submittedOrderId}`)
+  }
+
+  async function emailAction(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const submittedOrderId = String(formData.get('orderId') || '')
+
+    const targetOrder = await prisma.order.findFirst({
+      where: {
+        id: submittedOrderId,
+        eventId: id,
+        event: {
+          organizerId: profile.id,
+        },
+      },
+      include: {
+        event: {
+          select: {
+            title: true,
+            startDate: true,
+            endDate: true,
+            venue: true,
+            city: true,
+            country: true,
+            onlineUrl: true,
+          },
+        },
+      },
+    })
+
+    if (!targetOrder) {
+      throw new Error('Order not found')
+    }
+
+    await sendOrderConfirmationEmail(targetOrder.buyerEmail, {
+      orderNumber: targetOrder.orderNumber,
+      eventTitle: targetOrder.event.title,
+      eventDate: targetOrder.event.startDate.toISOString(),
+      eventLocation:
+        [targetOrder.event.venue, targetOrder.event.city, targetOrder.event.country].filter(Boolean).join(', ') ||
+        targetOrder.event.onlineUrl ||
+        'TBD',
+      tickets: [],
+      totalAmount: `${targetOrder.currency} ${targetOrder.totalAmount.toString()}`,
+      buyerName: `${targetOrder.buyerFirstName} ${targetOrder.buyerLastName}`.trim(),
+    })
+
+    revalidatePath(`/dashboard/events/${id}/orders/${submittedOrderId}`)
+  }
+
+  return (
+    <OrderDetailView
+      order={{
+        ...order,
+        subtotal: Number(order.subtotal.toString()),
+        discountAmount: Number(order.discountAmount.toString()),
+        totalAmount: Number(order.totalAmount.toString()),
+        items: order.items.map((item) => ({
+          ...item,
+          unitPrice: Number(item.unitPrice.toString()),
+          totalPrice: Number(item.totalPrice.toString()),
+        })),
+      }}
+      refundAction={refundAction}
+      emailAction={emailAction}
+    />
+  )
+}

--- a/src/app/(dashboard)/dashboard/events/[id]/orders/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/orders/page.tsx
@@ -1,0 +1,163 @@
+import Link from 'next/link'
+import { revalidatePath } from 'next/cache'
+import { notFound } from 'next/navigation'
+import { OrderStatus, PaymentMethod, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { OrderFilters } from '@/components/dashboard/OrderFilters'
+import { OrdersTable } from '@/components/dashboard/OrdersTable'
+
+type PageProps = {
+  params: Promise<{ id: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export default async function EventOrdersPage({ params, searchParams }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const { id } = await params
+  const qs = await searchParams
+
+  const search = readParam(qs.search)
+  const status = readParam(qs.status) as OrderStatus | undefined
+  const paymentMethod = readParam(qs.paymentMethod) as PaymentMethod | undefined
+  const dateFrom = readParam(qs.dateFrom)
+  const dateTo = readParam(qs.dateTo)
+
+  const event = await prisma.event.findFirst({
+    where: {
+      id,
+      organizerId: organizerProfile.id,
+    },
+    select: {
+      id: true,
+      title: true,
+    },
+  })
+
+  if (!event) {
+    notFound()
+  }
+
+  const where: Prisma.OrderWhereInput = {
+    eventId: id,
+  }
+
+  if (status && ['PENDING', 'PENDING_INVOICE', 'PAID', 'CANCELLED', 'REFUNDED', 'PARTIALLY_REFUNDED'].includes(status)) {
+    where.status = status
+  }
+
+  if (paymentMethod && ['PAYPAL', 'INVOICE', 'FREE'].includes(paymentMethod)) {
+    where.paymentMethod = paymentMethod
+  }
+
+  if (search) {
+    where.OR = [
+      { orderNumber: { contains: search, mode: 'insensitive' } },
+      { buyerEmail: { contains: search, mode: 'insensitive' } },
+      { buyerFirstName: { contains: search, mode: 'insensitive' } },
+      { buyerLastName: { contains: search, mode: 'insensitive' } },
+    ]
+  }
+
+  if (dateFrom || dateTo) {
+    where.createdAt = {
+      gte: dateFrom ? new Date(`${dateFrom}T00:00:00.000Z`) : undefined,
+      lte: dateTo ? new Date(`${dateTo}T23:59:59.999Z`) : undefined,
+    }
+  }
+
+  const orders = await prisma.order.findMany({
+    where,
+    select: {
+      id: true,
+      orderNumber: true,
+      buyerFirstName: true,
+      buyerLastName: true,
+      buyerEmail: true,
+      status: true,
+      paymentMethod: true,
+      totalAmount: true,
+      currency: true,
+      createdAt: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  })
+
+  async function applyBulkAction(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const action = String(formData.get('bulkAction') || '')
+
+    if (action !== 'cancel_all_filtered') return
+
+    await prisma.order.updateMany({
+      where: {
+        eventId: id,
+        event: {
+          organizerId: profile.id,
+        },
+        status: {
+          in: ['PENDING', 'PENDING_INVOICE'],
+        },
+      },
+      data: {
+        status: 'CANCELLED',
+        cancelledAt: new Date(),
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/orders`)
+  }
+
+  const exportParams = new URLSearchParams()
+  if (search) exportParams.set('search', search)
+  if (status) exportParams.set('status', status)
+  if (paymentMethod) exportParams.set('paymentMethod', paymentMethod)
+  if (dateFrom) exportParams.set('dateFrom', dateFrom)
+  if (dateTo) exportParams.set('dateTo', dateTo)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Orders</h1>
+          <p className="text-gray-600">Order management for {event.title}.</p>
+        </div>
+        <Link
+          href={`/api/dashboard/events/${id}/orders/export?${exportParams.toString()}`}
+          className="inline-flex rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700"
+        >
+          Export CSV
+        </Link>
+      </div>
+
+      <OrderFilters initial={{ search, status: status || '', paymentMethod: paymentMethod || '', dateFrom, dateTo }} />
+
+      <form action={applyBulkAction} className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="flex items-center gap-3">
+          <select name="bulkAction" className="h-10 rounded-md border border-gray-300 px-3 text-sm">
+            <option value="">Bulk actions</option>
+            <option value="cancel_all_filtered">Cancel all pending orders</option>
+          </select>
+          <button type="submit" className="h-10 rounded-md bg-blue-600 px-4 text-sm font-medium text-white">Apply</button>
+        </div>
+      </form>
+
+      <OrdersTable
+        eventId={event.id}
+        orders={orders.map((order) => ({
+          ...order,
+          totalAmount: Number(order.totalAmount.toString()),
+        }))}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/events/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/page.tsx
@@ -1,0 +1,146 @@
+import { notFound } from 'next/navigation'
+import { OrderStatus } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { EventDashboard } from '@/components/dashboard/EventDashboard'
+import { RecentOrders } from '@/components/dashboard/RecentOrders'
+
+const revenueStatuses: OrderStatus[] = ['PAID', 'PENDING_INVOICE']
+
+type PageProps = {
+  params: Promise<{ id: string }>
+}
+
+export default async function EventDetailDashboardPage({ params }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const { id } = await params
+
+  const event = await prisma.event.findFirst({
+    where: {
+      id,
+      organizerId: organizerProfile.id,
+    },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      status: true,
+      startDate: true,
+      endDate: true,
+      createdAt: true,
+      _count: {
+        select: {
+          orders: true,
+          ticketTypes: true,
+        },
+      },
+      ticketTypes: {
+        select: {
+          id: true,
+          name: true,
+          soldCount: true,
+          maxCapacity: true,
+        },
+      },
+    },
+  })
+
+  if (!event) {
+    notFound()
+  }
+
+  const [orderStats, revenueAgg, ticketItemAgg, recentOrders] = await prisma.$transaction([
+    prisma.order.findMany({
+      where: { eventId: event.id },
+      select: { status: true },
+    }),
+    prisma.order.aggregate({
+      where: {
+        eventId: event.id,
+        status: { in: revenueStatuses },
+      },
+      _sum: {
+        totalAmount: true,
+      },
+    }),
+    prisma.orderItem.groupBy({
+      by: ['ticketTypeId'],
+      orderBy: {
+        ticketTypeId: 'asc',
+      },
+      where: {
+        order: {
+          eventId: event.id,
+          status: { in: revenueStatuses },
+        },
+      },
+      _sum: {
+        quantity: true,
+        totalPrice: true,
+      },
+    }),
+    prisma.order.findMany({
+      where: {
+        eventId: event.id,
+      },
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        currency: true,
+        buyerEmail: true,
+        createdAt: true,
+        event: {
+          select: {
+            id: true,
+            title: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 8,
+    }),
+  ])
+
+  const countsByStatus = orderStats.reduce<Record<string, number>>((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1
+    return acc
+  }, {})
+
+  const ticketsByType = event.ticketTypes.map((ticketType) => {
+    const sales = ticketItemAgg.find((item) => item.ticketTypeId === ticketType.id)
+    return {
+      name: ticketType.name,
+      sold: sales?._sum?.quantity ?? 0,
+      revenue: Number(sales?._sum?.totalPrice?.toString() ?? '0'),
+      remaining: ticketType.maxCapacity === null ? null : Math.max(ticketType.maxCapacity - ticketType.soldCount, 0),
+    }
+  })
+
+  return (
+    <div className="space-y-6">
+      <EventDashboard
+        event={event}
+        stats={{
+          totalRevenue: Number(revenueAgg._sum.totalAmount?.toString() ?? '0'),
+          totalOrders: Object.values(countsByStatus).reduce((sum, count) => sum + count, 0),
+          paidOrders: countsByStatus.PAID ?? 0,
+          pendingInvoiceOrders: countsByStatus.PENDING_INVOICE ?? 0,
+          cancelledOrders: countsByStatus.CANCELLED ?? 0,
+          refundedOrders: (countsByStatus.REFUNDED ?? 0) + (countsByStatus.PARTIALLY_REFUNDED ?? 0),
+          ticketsByType,
+        }}
+      />
+
+      <RecentOrders
+        orders={recentOrders.map((order) => ({
+          ...order,
+          totalAmount: Number(order.totalAmount.toString()),
+        }))}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/events/[id]/tickets/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/tickets/page.tsx
@@ -1,0 +1,228 @@
+import { revalidatePath } from 'next/cache'
+import { notFound } from 'next/navigation'
+import { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { TicketTypeList } from '@/components/dashboard/TicketTypeList'
+import { TicketTypeForm } from '@/components/dashboard/TicketTypeForm'
+
+type PageProps = {
+  params: Promise<{ id: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export default async function TicketTypesPage({ params, searchParams }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const { id } = await params
+  const qs = await searchParams
+  const editId = readParam(qs.edit)
+
+  const event = await prisma.event.findFirst({
+    where: {
+      id,
+      organizerId: organizerProfile.id,
+    },
+    select: {
+      id: true,
+      title: true,
+      ticketTypes: {
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          price: true,
+          currency: true,
+          soldCount: true,
+          maxCapacity: true,
+          minPerOrder: true,
+          maxPerOrder: true,
+          isVisible: true,
+        },
+      },
+    },
+  })
+
+  if (!event) {
+    notFound()
+  }
+
+  async function createTicketType(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+
+    const eventCheck = await prisma.event.findFirst({
+      where: { id, organizerId: profile.id },
+      select: { id: true },
+    })
+
+    if (!eventCheck) {
+      throw new Error('Event not found')
+    }
+
+    const name = String(formData.get('name') || '').trim()
+    const description = String(formData.get('description') || '').trim() || null
+    const price = new Prisma.Decimal(String(formData.get('price') || '0'))
+    const currency = String(formData.get('currency') || 'EUR').trim() || 'EUR'
+    const maxCapacityRaw = String(formData.get('maxCapacity') || '').trim()
+    const maxCapacity = maxCapacityRaw ? Number(maxCapacityRaw) : null
+    const minPerOrder = Number(String(formData.get('minPerOrder') || '1'))
+    const maxPerOrder = Number(String(formData.get('maxPerOrder') || '10'))
+    const isVisible = String(formData.get('isVisible') || 'true') === 'true'
+
+    await prisma.ticketType.create({
+      data: {
+        eventId: eventCheck.id,
+        name,
+        description,
+        price,
+        currency,
+        maxCapacity,
+        minPerOrder,
+        maxPerOrder,
+        isVisible,
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/tickets`)
+  }
+
+  async function updateTicketType(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+
+    const ticketTypeId = String(formData.get('ticketTypeId') || '')
+    if (!ticketTypeId) return
+
+    const ticketType = await prisma.ticketType.findFirst({
+      where: {
+        id: ticketTypeId,
+        event: {
+          id,
+          organizerId: profile.id,
+        },
+      },
+      select: { id: true },
+    })
+
+    if (!ticketType) {
+      throw new Error('Ticket type not found')
+    }
+
+    const name = String(formData.get('name') || '').trim()
+    const description = String(formData.get('description') || '').trim() || null
+    const price = new Prisma.Decimal(String(formData.get('price') || '0'))
+    const currency = String(formData.get('currency') || 'EUR').trim() || 'EUR'
+    const maxCapacityRaw = String(formData.get('maxCapacity') || '').trim()
+    const maxCapacity = maxCapacityRaw ? Number(maxCapacityRaw) : null
+    const minPerOrder = Number(String(formData.get('minPerOrder') || '1'))
+    const maxPerOrder = Number(String(formData.get('maxPerOrder') || '10'))
+    const isVisible = String(formData.get('isVisible') || 'true') === 'true'
+
+    await prisma.ticketType.update({
+      where: { id: ticketType.id },
+      data: {
+        name,
+        description,
+        price,
+        currency,
+        maxCapacity,
+        minPerOrder,
+        maxPerOrder,
+        isVisible,
+      },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/tickets`)
+  }
+
+  async function deleteTicketType(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+    const ticketTypeId = String(formData.get('ticketTypeId') || '')
+
+    const ticketType = await prisma.ticketType.findFirst({
+      where: {
+        id: ticketTypeId,
+        event: {
+          id,
+          organizerId: profile.id,
+        },
+      },
+      select: {
+        id: true,
+        soldCount: true,
+      },
+    })
+
+    if (!ticketType) return
+
+    if (ticketType.soldCount > 0) {
+      throw new Error('Cannot delete a ticket type with sold tickets')
+    }
+
+    await prisma.ticketType.delete({
+      where: { id: ticketType.id },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/tickets`)
+  }
+
+  const editableTicketType = editId ? event.ticketTypes.find((ticketType) => ticketType.id === editId) : undefined
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Ticket Types</h1>
+        <p className="text-gray-600">Manage ticket inventory and pricing for {event.title}.</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <TicketTypeForm title="Create Ticket Type" submitLabel="Create Ticket Type" action={createTicketType} />
+        <TicketTypeForm
+          title="Edit Ticket Type"
+          submitLabel="Update Ticket Type"
+          action={updateTicketType}
+          initial={
+            editableTicketType
+              ? {
+                  id: editableTicketType.id,
+                  name: editableTicketType.name,
+                  description: editableTicketType.description,
+                  price: Number(editableTicketType.price.toString()),
+                  currency: editableTicketType.currency,
+                  maxCapacity: editableTicketType.maxCapacity,
+                  minPerOrder: editableTicketType.minPerOrder,
+                  maxPerOrder: editableTicketType.maxPerOrder,
+                  isVisible: editableTicketType.isVisible,
+                }
+              : undefined
+          }
+        />
+      </div>
+
+      <TicketTypeList
+        ticketTypes={event.ticketTypes.map((ticketType) => ({
+          id: ticketType.id,
+          name: ticketType.name,
+          price: Number(ticketType.price.toString()),
+          currency: ticketType.currency,
+          soldCount: ticketType.soldCount,
+          maxCapacity: ticketType.maxCapacity,
+          isVisible: ticketType.isVisible,
+        }))}
+        deleteAction={deleteTicketType}
+      />
+
+      <p className="text-xs text-gray-500">Tip: add <code>?edit=ticketTypeId</code> to the URL to prefill the edit form for a specific ticket type.</p>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/events/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/page.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link'
+import { EventStatus, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { EventsTable } from '@/components/dashboard/EventsTable'
+
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function param(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export default async function OrganizerEventsPage({ searchParams }: PageProps) {
+  const { organizerProfile } = await requireOrganizerProfile()
+  const params = await searchParams
+
+  const status = param(params.status) as EventStatus | undefined
+  const query = param(params.q)
+
+  const where: Prisma.EventWhereInput = {
+    organizerId: organizerProfile.id,
+  }
+
+  if (status && ['DRAFT', 'PUBLISHED', 'CANCELLED', 'COMPLETED'].includes(status)) {
+    where.status = status
+  }
+
+  if (query) {
+    where.title = {
+      contains: query,
+      mode: 'insensitive',
+    }
+  }
+
+  const events = await prisma.event.findMany({
+    where,
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      startDate: true,
+      endDate: true,
+      status: true,
+      visibility: true,
+      _count: {
+        select: {
+          orders: true,
+          ticketTypes: true,
+        },
+      },
+    },
+    orderBy: {
+      startDate: 'desc',
+    },
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Your Events</h1>
+          <p className="text-gray-600">Search, filter, and manage all organizer events.</p>
+        </div>
+        <Link href="/create-event" className="inline-flex rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white">
+          Create New Event
+        </Link>
+      </div>
+
+      <form className="grid grid-cols-1 gap-3 rounded-xl border border-gray-200 bg-white p-4 md:grid-cols-4">
+        <div className="md:col-span-2">
+          <label htmlFor="q" className="text-xs font-medium text-gray-600">Search by title</label>
+          <input id="q" name="q" defaultValue={query || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm" />
+        </div>
+        <div>
+          <label htmlFor="status" className="text-xs font-medium text-gray-600">Status</label>
+          <select id="status" name="status" defaultValue={status || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm">
+            <option value="">All</option>
+            <option value="DRAFT">DRAFT</option>
+            <option value="PUBLISHED">PUBLISHED</option>
+            <option value="CANCELLED">CANCELLED</option>
+            <option value="COMPLETED">COMPLETED</option>
+          </select>
+        </div>
+        <div className="flex items-end">
+          <button type="submit" className="h-10 rounded-md bg-blue-600 px-4 text-sm font-medium text-white">Apply</button>
+        </div>
+      </form>
+
+      <EventsTable events={events} />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getCurrentUser, hasRole } from '@/lib/auth'
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const user = await getCurrentUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  if (!hasRole(user.roles, 'ORGANIZER')) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-red-700">
+          Organizer role is required to access the dashboard.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-8 lg:grid-cols-[240px_1fr]">
+      <aside className="h-fit rounded-xl border border-gray-200 bg-white p-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Organizer</h2>
+        <nav className="mt-3 space-y-1 text-sm">
+          <Link href="/dashboard" className="block rounded-md px-3 py-2 text-gray-700 hover:bg-gray-50">Overview</Link>
+          <Link href="/dashboard/events" className="block rounded-md px-3 py-2 text-gray-700 hover:bg-gray-50">Events</Link>
+          <Link href="/dashboard/settings" className="block rounded-md px-3 py-2 text-gray-700 hover:bg-gray-50">Profile Settings</Link>
+          <Link href="/dashboard/settings/account" className="block rounded-md px-3 py-2 text-gray-700 hover:bg-gray-50">Account Settings</Link>
+        </nav>
+      </aside>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,126 @@
+import Link from 'next/link'
+import { OrderStatus } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { DashboardStats } from '@/components/dashboard/DashboardStats'
+import { UpcomingEvents } from '@/components/dashboard/UpcomingEvents'
+import { RecentOrders } from '@/components/dashboard/RecentOrders'
+
+const revenueStatuses: OrderStatus[] = ['PAID', 'PENDING_INVOICE']
+
+export default async function DashboardHomePage() {
+  const { organizerProfile } = await requireOrganizerProfile()
+
+  const now = new Date()
+
+  const [eventsByStatus, ticketAgg, revenueAgg, upcomingEvents, recentOrders] = await prisma.$transaction([
+    prisma.event.findMany({
+      where: { organizerId: organizerProfile.id },
+      select: { status: true },
+    }),
+    prisma.ticketType.aggregate({
+      where: {
+        event: {
+          organizerId: organizerProfile.id,
+        },
+      },
+      _sum: {
+        soldCount: true,
+      },
+    }),
+    prisma.order.aggregate({
+      where: {
+        event: {
+          organizerId: organizerProfile.id,
+        },
+        status: { in: revenueStatuses },
+      },
+      _sum: {
+        totalAmount: true,
+      },
+    }),
+    prisma.event.findMany({
+      where: {
+        organizerId: organizerProfile.id,
+        startDate: { gte: now },
+      },
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        startDate: true,
+        status: true,
+      },
+      orderBy: {
+        startDate: 'asc',
+      },
+      take: 6,
+    }),
+    prisma.order.findMany({
+      where: {
+        event: {
+          organizerId: organizerProfile.id,
+        },
+      },
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        currency: true,
+        buyerEmail: true,
+        createdAt: true,
+        event: {
+          select: {
+            id: true,
+            title: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 8,
+    }),
+  ])
+
+  const statusCounts = eventsByStatus.reduce<Record<string, number>>((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1
+    return acc
+  }, {})
+
+  const stats = {
+    totalEvents: Object.values(statusCounts).reduce((sum, count) => sum + count, 0),
+    publishedEvents: statusCounts.PUBLISHED ?? 0,
+    draftEvents: statusCounts.DRAFT ?? 0,
+    upcomingEvents: upcomingEvents.length,
+    totalTicketsSold: ticketAgg._sum.soldCount ?? 0,
+    totalRevenue: Number(revenueAgg._sum.totalAmount?.toString() ?? '0'),
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Welcome, {organizerProfile.orgName}</h1>
+          <p className="text-gray-600">Overview of your events, orders, and revenue.</p>
+        </div>
+        <Link href="/create-event" className="inline-flex rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white">
+          Create Event
+        </Link>
+      </div>
+
+      <DashboardStats stats={stats} />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <UpcomingEvents events={upcomingEvents} />
+        <RecentOrders
+          orders={recentOrders.map((order) => ({
+            ...order,
+            totalAmount: Number(order.totalAmount.toString()),
+          }))}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/settings/account/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/account/page.tsx
@@ -1,0 +1,99 @@
+import bcrypt from 'bcryptjs'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { AccountSettings } from '@/components/dashboard/AccountSettings'
+
+export default async function AccountSettingsPage() {
+  const user = await requireRole('ORGANIZER')
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: {
+      id: true,
+      email: true,
+      passwordHash: true,
+      accounts: {
+        select: {
+          provider: true,
+        },
+      },
+    },
+  })
+
+  if (!dbUser) {
+    redirect('/login')
+  }
+
+  async function updateEmailAction(formData: FormData) {
+    'use server'
+
+    const currentUser = await requireRole('ORGANIZER')
+    const email = String(formData.get('email') || '').trim().toLowerCase()
+
+    if (!email) return
+
+    await prisma.user.update({
+      where: { id: currentUser.id },
+      data: { email },
+    })
+
+    revalidatePath('/dashboard/settings/account')
+  }
+
+  async function changePasswordAction(formData: FormData) {
+    'use server'
+
+    const currentUser = await requireRole('ORGANIZER')
+    const currentPassword = String(formData.get('currentPassword') || '')
+    const newPassword = String(formData.get('newPassword') || '')
+
+    if (!currentPassword || !newPassword) return
+
+    const currentDbUser = await prisma.user.findUnique({
+      where: { id: currentUser.id },
+      select: {
+        id: true,
+        passwordHash: true,
+      },
+    })
+
+    if (!currentDbUser?.passwordHash) return
+
+    const isValid = await bcrypt.compare(currentPassword, currentDbUser.passwordHash)
+    if (!isValid) return
+
+    const newHash = await bcrypt.hash(newPassword, 12)
+
+    await prisma.user.update({
+      where: { id: currentUser.id },
+      data: { passwordHash: newHash },
+    })
+
+    revalidatePath('/dashboard/settings/account')
+  }
+
+  async function deleteAccountAction(formData: FormData) {
+    'use server'
+    void formData
+
+    const currentUser = await requireRole('ORGANIZER')
+
+    await prisma.user.delete({
+      where: { id: currentUser.id },
+    })
+
+    redirect('/')
+  }
+
+  return (
+    <AccountSettings
+      userEmail={dbUser.email}
+      connectedAccounts={dbUser.accounts.map((account) => account.provider)}
+      updateEmailAction={updateEmailAction}
+      changePasswordAction={changePasswordAction}
+      deleteAccountAction={deleteAccountAction}
+    />
+  )
+}

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -1,0 +1,50 @@
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { OrganizerProfileForm } from '@/components/dashboard/OrganizerProfileForm'
+
+export default async function OrganizerSettingsPage() {
+  const { organizerProfile } = await requireOrganizerProfile()
+
+  async function updateOrganizerProfile(formData: FormData) {
+    'use server'
+
+    const { organizerProfile: profile } = await requireOrganizerProfile()
+
+    const orgName = String(formData.get('orgName') || '').trim()
+    const description = String(formData.get('description') || '').trim() || null
+    const website = String(formData.get('website') || '').trim() || null
+    const logo = String(formData.get('logo') || '').trim() || null
+
+    const socialLinks = {
+      twitter: String(formData.get('twitter') || '').trim(),
+      linkedin: String(formData.get('linkedin') || '').trim(),
+    }
+
+    await prisma.organizerProfile.update({
+      where: { id: profile.id },
+      data: {
+        orgName,
+        description,
+        website,
+        logo,
+        socialLinks,
+      },
+    })
+
+    revalidatePath('/dashboard/settings')
+  }
+
+  return (
+    <OrganizerProfileForm
+      initial={{
+        orgName: organizerProfile.orgName,
+        description: organizerProfile.description,
+        logo: organizerProfile.logo,
+        website: organizerProfile.website,
+        socialLinks: (organizerProfile.socialLinks as Record<string, string> | null) || {},
+      }}
+      action={updateOrganizerProfile}
+    />
+  )
+}

--- a/src/app/api/dashboard/events/[id]/orders/export/route.ts
+++ b/src/app/api/dashboard/events/[id]/orders/export/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server'
+import { OrderStatus, PaymentMethod, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+
+type RouteContext = {
+  params: Promise<{ id: string }>
+}
+
+function csvCell(value: string | number | null) {
+  const str = value === null ? '' : String(value)
+  return `"${str.replaceAll('"', '""')}"`
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const { organizerProfile } = await requireOrganizerProfile()
+    const { id } = await context.params
+
+    const { searchParams } = new URL(request.url)
+    const search = searchParams.get('search') || undefined
+    const status = searchParams.get('status') as OrderStatus | null
+    const paymentMethod = searchParams.get('paymentMethod') as PaymentMethod | null
+    const dateFrom = searchParams.get('dateFrom') || undefined
+    const dateTo = searchParams.get('dateTo') || undefined
+
+    const where: Prisma.OrderWhereInput = {
+      eventId: id,
+      event: {
+        organizerId: organizerProfile.id,
+      },
+    }
+
+    if (status && ['PENDING', 'PENDING_INVOICE', 'PAID', 'CANCELLED', 'REFUNDED', 'PARTIALLY_REFUNDED'].includes(status)) {
+      where.status = status
+    }
+
+    if (paymentMethod && ['PAYPAL', 'INVOICE', 'FREE'].includes(paymentMethod)) {
+      where.paymentMethod = paymentMethod
+    }
+
+    if (search) {
+      where.OR = [
+        { orderNumber: { contains: search, mode: 'insensitive' } },
+        { buyerEmail: { contains: search, mode: 'insensitive' } },
+        { buyerFirstName: { contains: search, mode: 'insensitive' } },
+        { buyerLastName: { contains: search, mode: 'insensitive' } },
+      ]
+    }
+
+    if (dateFrom || dateTo) {
+      where.createdAt = {
+        gte: dateFrom ? new Date(`${dateFrom}T00:00:00.000Z`) : undefined,
+        lte: dateTo ? new Date(`${dateTo}T23:59:59.999Z`) : undefined,
+      }
+    }
+
+    const orders = await prisma.order.findMany({
+      where,
+      select: {
+        orderNumber: true,
+        buyerFirstName: true,
+        buyerLastName: true,
+        buyerEmail: true,
+        status: true,
+        paymentMethod: true,
+        subtotal: true,
+        discountAmount: true,
+        totalAmount: true,
+        currency: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    const header = ['orderNumber', 'buyerName', 'buyerEmail', 'status', 'paymentMethod', 'subtotal', 'discountAmount', 'totalAmount', 'currency', 'createdAt']
+    const lines = [header.join(',')]
+
+    for (const order of orders) {
+      lines.push([
+        csvCell(order.orderNumber),
+        csvCell(`${order.buyerFirstName} ${order.buyerLastName}`.trim()),
+        csvCell(order.buyerEmail),
+        csvCell(order.status),
+        csvCell(order.paymentMethod),
+        csvCell(order.subtotal.toString()),
+        csvCell(order.discountAmount.toString()),
+        csvCell(order.totalAmount.toString()),
+        csvCell(order.currency),
+        csvCell(order.createdAt.toISOString()),
+      ].join(','))
+    }
+
+    const csv = lines.join('\n')
+
+    return new NextResponse(csv, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="event-${id}-orders.csv"`,
+      },
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Unauthorized') {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      if (error.message.includes('Forbidden')) {
+        return NextResponse.json({ error: error.message }, { status: 403 })
+      }
+    }
+
+    console.error('Order export failed:', error)
+    return NextResponse.json({ error: 'Failed to export orders' }, { status: 500 })
+  }
+}

--- a/src/app/api/dashboard/statistics/route.ts
+++ b/src/app/api/dashboard/statistics/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server'
+import { OrderStatus } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+
+const revenueStatuses: OrderStatus[] = ['PAID', 'PENDING_INVOICE']
+
+export async function GET() {
+  try {
+    const { organizerProfile } = await requireOrganizerProfile()
+
+    const now = new Date()
+
+    const [eventCounts, ticketStats, revenueStats, recentRevenueByEvent] = await prisma.$transaction([
+      prisma.event.findMany({
+        where: {
+          organizerId: organizerProfile.id,
+        },
+        select: {
+          status: true,
+        },
+      }),
+      prisma.ticketType.aggregate({
+        where: {
+          event: {
+            organizerId: organizerProfile.id,
+          },
+        },
+        _sum: {
+          soldCount: true,
+        },
+      }),
+      prisma.order.aggregate({
+        where: {
+          event: {
+            organizerId: organizerProfile.id,
+          },
+          status: {
+            in: revenueStatuses,
+          },
+        },
+        _sum: {
+          totalAmount: true,
+        },
+        _count: {
+          _all: true,
+        },
+      }),
+      prisma.order.groupBy({
+        by: ['eventId'],
+        where: {
+          event: {
+            organizerId: organizerProfile.id,
+          },
+          status: {
+            in: revenueStatuses,
+          },
+        },
+        _sum: {
+          totalAmount: true,
+        },
+        orderBy: {
+          _sum: {
+            totalAmount: 'desc',
+          },
+        },
+        take: 5,
+      }),
+    ])
+
+    const statusCounts = eventCounts.reduce<Record<string, number>>((acc, row) => {
+      acc[row.status] = (acc[row.status] ?? 0) + 1
+      return acc
+    }, {})
+
+    const topEventIds = recentRevenueByEvent.map((item) => item.eventId)
+    const topEvents = topEventIds.length
+      ? await prisma.event.findMany({
+          where: { id: { in: topEventIds } },
+          select: { id: true, title: true },
+        })
+      : []
+
+    const topEventMap = new Map(topEvents.map((event) => [event.id, event.title]))
+
+    const upcomingEvents = await prisma.event.count({
+      where: {
+        organizerId: organizerProfile.id,
+        status: 'PUBLISHED',
+        startDate: {
+          gte: now,
+        },
+      },
+    })
+
+    return NextResponse.json({
+      data: {
+        totalEvents: Object.values(statusCounts).reduce((sum, count) => sum + count, 0),
+        publishedEvents: statusCounts.PUBLISHED ?? 0,
+        draftEvents: statusCounts.DRAFT ?? 0,
+        cancelledEvents: statusCounts.CANCELLED ?? 0,
+        completedEvents: statusCounts.COMPLETED ?? 0,
+        upcomingEvents,
+        totalTicketsSold: ticketStats._sum?.soldCount ?? 0,
+        totalRevenue: Number(revenueStats._sum?.totalAmount?.toString() ?? '0'),
+        totalRevenueOrders: revenueStats._count?._all ?? 0,
+        topRevenueEvents: recentRevenueByEvent.map((item) => ({
+          eventId: item.eventId,
+          title: topEventMap.get(item.eventId) ?? 'Unknown event',
+          revenue: Number(item._sum?.totalAmount?.toString() ?? '0'),
+        })),
+      },
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Unauthorized') {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      if (error.message.includes('Forbidden')) {
+        return NextResponse.json({ error: error.message }, { status: 403 })
+      }
+    }
+
+    console.error('Dashboard statistics failed:', error)
+    return NextResponse.json({ error: 'Failed to fetch dashboard statistics' }, { status: 500 })
+  }
+}

--- a/src/app/api/events/[id]/statistics/route.ts
+++ b/src/app/api/events/[id]/statistics/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server'
+import { OrderStatus } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+
+type RouteContext = {
+  params: Promise<{ id: string }>
+}
+
+const revenueStatuses: OrderStatus[] = ['PAID', 'PENDING_INVOICE']
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { organizerProfile } = await requireOrganizerProfile()
+    const { id } = await context.params
+
+    const event = await prisma.event.findFirst({
+      where: {
+        id,
+        organizerId: organizerProfile.id,
+      },
+      select: {
+        id: true,
+        title: true,
+        ticketTypes: {
+          select: {
+            id: true,
+            name: true,
+            soldCount: true,
+            maxCapacity: true,
+          },
+        },
+      },
+    })
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const [orderStats, paidRevenueAgg, paidItemGroups] = await prisma.$transaction([
+      prisma.order.findMany({
+        where: { eventId: id },
+        select: { status: true },
+      }),
+      prisma.order.aggregate({
+        where: {
+          eventId: id,
+          status: { in: revenueStatuses },
+        },
+        _sum: {
+          totalAmount: true,
+        },
+      }),
+      prisma.orderItem.groupBy({
+        by: ['ticketTypeId'],
+        orderBy: {
+          ticketTypeId: 'asc',
+        },
+        where: {
+          order: {
+            eventId: id,
+            status: { in: revenueStatuses },
+          },
+        },
+        _sum: {
+          quantity: true,
+          totalPrice: true,
+        },
+      }),
+    ])
+
+    const countsByStatus = orderStats.reduce<Record<string, number>>((acc, row) => {
+      acc[row.status] = (acc[row.status] ?? 0) + 1
+      return acc
+    }, {})
+
+    const byTicketType = event.ticketTypes.map((ticketType) => {
+      const sales = paidItemGroups.find((group) => group.ticketTypeId === ticketType.id)
+      const sold = sales?._sum?.quantity ?? 0
+      const revenue = Number(sales?._sum?.totalPrice?.toString() ?? '0')
+
+      return {
+        ticketTypeId: ticketType.id,
+        name: ticketType.name,
+        sold,
+        revenue,
+        remaining: ticketType.maxCapacity === null ? null : Math.max(ticketType.maxCapacity - ticketType.soldCount, 0),
+      }
+    })
+
+    const payload = {
+      eventId: event.id,
+      eventTitle: event.title,
+      totalRevenue: Number(paidRevenueAgg._sum.totalAmount?.toString() ?? '0'),
+      totalOrders: Object.values(countsByStatus).reduce((sum, count) => sum + count, 0),
+      paidOrders: countsByStatus.PAID ?? 0,
+      pendingInvoiceOrders: countsByStatus.PENDING_INVOICE ?? 0,
+      cancelledOrders: countsByStatus.CANCELLED ?? 0,
+      refundedOrders: (countsByStatus.REFUNDED ?? 0) + (countsByStatus.PARTIALLY_REFUNDED ?? 0),
+      ticketsByType: byTicketType,
+    }
+
+    return NextResponse.json({ data: payload })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Unauthorized') {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      if (error.message.includes('Forbidden')) {
+        return NextResponse.json({ error: error.message }, { status: 403 })
+      }
+    }
+
+    console.error('Event statistics failed:', error)
+    return NextResponse.json({ error: 'Failed to fetch event statistics' }, { status: 500 })
+  }
+}

--- a/src/components/dashboard/AccountSettings.tsx
+++ b/src/components/dashboard/AccountSettings.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type AccountSettingsProps = {
+  userEmail: string
+  connectedAccounts: string[]
+  updateEmailAction: (formData: FormData) => Promise<void>
+  changePasswordAction: (formData: FormData) => Promise<void>
+  deleteAccountAction: (formData: FormData) => Promise<void>
+}
+
+export function AccountSettings({ userEmail, connectedAccounts, updateEmailAction, changePasswordAction, deleteAccountAction }: AccountSettingsProps) {
+  return (
+    <div className="space-y-6">
+      <form action={updateEmailAction} className="space-y-4 rounded-xl border border-gray-200 bg-white p-6">
+        <h1 className="text-2xl font-bold text-gray-900">Account Settings</h1>
+        <div>
+          <Label htmlFor="email" required>Email</Label>
+          <Input id="email" name="email" type="email" defaultValue={userEmail} required />
+        </div>
+        <Button type="submit">Update Email</Button>
+      </form>
+
+      <form action={changePasswordAction} className="space-y-4 rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Change Password</h2>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div>
+            <Label htmlFor="currentPassword" required>Current Password</Label>
+            <Input id="currentPassword" name="currentPassword" type="password" required />
+          </div>
+          <div>
+            <Label htmlFor="newPassword" required>New Password</Label>
+            <Input id="newPassword" name="newPassword" type="password" required />
+          </div>
+        </div>
+        <Button type="submit">Change Password</Button>
+      </form>
+
+      <form action={deleteAccountAction} className="space-y-4 rounded-xl border border-red-200 bg-red-50 p-6">
+        <h2 className="text-lg font-semibold text-red-900">Delete Account</h2>
+        <p className="text-sm text-red-800">This will remove your account and organizer profile. This action cannot be undone.</p>
+        <input type="hidden" name="confirm" value="true" />
+        <Button type="submit" variant="destructive">Delete Account</Button>
+      </form>
+
+      <section className="space-y-3 rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Connected Accounts</h2>
+        {connectedAccounts.length === 0 ? (
+          <p className="text-sm text-gray-600">No OAuth accounts connected.</p>
+        ) : (
+          <ul className="list-disc pl-5 text-sm text-gray-700">
+            {connectedAccounts.map((provider) => (
+              <li key={provider}>{provider}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/dashboard/DashboardStats.tsx
+++ b/src/components/dashboard/DashboardStats.tsx
@@ -1,0 +1,34 @@
+import { formatCurrency } from '@/lib/utils'
+
+type DashboardStatsProps = {
+  stats: {
+    totalEvents: number
+    publishedEvents: number
+    draftEvents: number
+    upcomingEvents: number
+    totalTicketsSold: number
+    totalRevenue: number
+  }
+}
+
+export function DashboardStats({ stats }: DashboardStatsProps) {
+  const cards = [
+    { label: 'Total Events', value: String(stats.totalEvents) },
+    { label: 'Published', value: String(stats.publishedEvents) },
+    { label: 'Draft', value: String(stats.draftEvents) },
+    { label: 'Upcoming', value: String(stats.upcomingEvents) },
+    { label: 'Tickets Sold', value: String(stats.totalTicketsSold) },
+    { label: 'Revenue', value: formatCurrency(stats.totalRevenue) },
+  ]
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {cards.map((card) => (
+        <div key={card.label} className="rounded-xl border border-gray-200 bg-white p-5">
+          <p className="text-sm text-gray-500">{card.label}</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{card.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/dashboard/DiscountCodeForm.tsx
+++ b/src/components/dashboard/DiscountCodeForm.tsx
@@ -1,0 +1,68 @@
+import { DiscountType } from '@prisma/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type DiscountCodeFormProps = {
+  title: string
+  submitLabel: string
+  action: (formData: FormData) => Promise<void>
+  initial?: {
+    id: string
+    code: string
+    discountType: DiscountType
+    discountValue: number
+    maxUses: number | null
+    isActive: boolean
+  }
+}
+
+export function DiscountCodeForm({ title, submitLabel, action, initial }: DiscountCodeFormProps) {
+  return (
+    <form action={action} className="space-y-4 rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      {initial ? <input type="hidden" name="discountCodeId" value={initial.id} /> : null}
+      <div>
+        <Label htmlFor={`${title}-code`} required>Code</Label>
+        <Input id={`${title}-code`} name="code" defaultValue={initial?.code || ''} required />
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <Label htmlFor={`${title}-type`} required>Type</Label>
+          <select
+            id={`${title}-type`}
+            name="discountType"
+            defaultValue={initial?.discountType || 'PERCENTAGE'}
+            className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm"
+          >
+            <option value="PERCENTAGE">Percentage</option>
+            <option value="FIXED_AMOUNT">Fixed Amount</option>
+            <option value="FREE_TICKET">Free Ticket</option>
+            <option value="INVOICE">Invoice</option>
+          </select>
+        </div>
+        <div>
+          <Label htmlFor={`${title}-value`} required>Value</Label>
+          <Input id={`${title}-value`} name="discountValue" type="number" min="0" step="0.01" defaultValue={initial?.discountValue ?? 0} required />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-maxUses`}>Max Uses</Label>
+          <Input id={`${title}-maxUses`} name="maxUses" type="number" min="1" defaultValue={initial?.maxUses ?? ''} />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-isActive`}>Status</Label>
+          <select
+            id={`${title}-isActive`}
+            name="isActive"
+            defaultValue={initial?.isActive === false ? 'false' : 'true'}
+            className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm"
+          >
+            <option value="true">Active</option>
+            <option value="false">Inactive</option>
+          </select>
+        </div>
+      </div>
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  )
+}

--- a/src/components/dashboard/DiscountCodeList.tsx
+++ b/src/components/dashboard/DiscountCodeList.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/button'
+
+type DiscountCodeListProps = {
+  discountCodes: Array<{
+    id: string
+    code: string
+    discountType: string
+    discountValue: number
+    usedCount: number
+    maxUses: number | null
+    isActive: boolean
+  }>
+  deleteAction: (formData: FormData) => Promise<void>
+}
+
+export function DiscountCodeList({ discountCodes, deleteAction }: DiscountCodeListProps) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6">
+      <h2 className="text-lg font-semibold text-gray-900">Discount Codes</h2>
+      {discountCodes.length === 0 ? (
+        <p className="mt-3 text-sm text-gray-600">No discount codes configured.</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {discountCodes.map((discountCode) => (
+            <div key={discountCode.id} className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 p-3">
+              <div>
+                <p className="font-medium text-gray-900">{discountCode.code}</p>
+                <p className="text-sm text-gray-600">
+                  {discountCode.discountType} · Value: {discountCode.discountValue} · Uses: {discountCode.usedCount}/{discountCode.maxUses ?? 'Unlimited'} · {discountCode.isActive ? 'Active' : 'Inactive'}
+                </p>
+              </div>
+              <form action={deleteAction}>
+                <input type="hidden" name="discountCodeId" value={discountCode.id} />
+                <Button variant="destructive" size="sm">Delete</Button>
+              </form>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/dashboard/EventDashboard.tsx
+++ b/src/components/dashboard/EventDashboard.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link'
+import { EventStatus } from '@prisma/client'
+import { Button } from '@/components/ui/button'
+import { EventStatusBadge } from '@/components/dashboard/EventStatusBadge'
+import { SalesChart } from '@/components/dashboard/SalesChart'
+import { formatCurrency, formatDateTime } from '@/lib/utils'
+
+type EventDashboardProps = {
+  event: {
+    id: string
+    slug: string
+    title: string
+    status: EventStatus
+    startDate: Date
+    endDate: Date
+    createdAt: Date
+    _count: {
+      orders: number
+      ticketTypes: number
+    }
+  }
+  stats: {
+    totalRevenue: number
+    totalOrders: number
+    paidOrders: number
+    pendingInvoiceOrders: number
+    cancelledOrders: number
+    refundedOrders: number
+    ticketsByType: Array<{
+      name: string
+      revenue: number
+      sold: number
+      remaining: number | null
+    }>
+  }
+}
+
+export function EventDashboard({ event, stats }: EventDashboardProps) {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{event.title}</h1>
+            <div className="mt-2 flex items-center gap-2">
+              <EventStatusBadge status={event.status} />
+              <span className="text-sm text-gray-500">Created {formatDateTime(event.createdAt)}</span>
+            </div>
+            <p className="mt-2 text-sm text-gray-600">
+              {formatDateTime(event.startDate)} - {formatDateTime(event.endDate)}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Link href={`/dashboard/events/${event.id}/edit`}>
+              <Button variant="outline">Edit Event</Button>
+            </Link>
+            <Link href={`/dashboard/events/${event.id}/tickets`}>
+              <Button variant="outline">Manage Tickets</Button>
+            </Link>
+            <Link href={`/dashboard/events/${event.id}/discounts`}>
+              <Button variant="outline">Manage Discounts</Button>
+            </Link>
+            <Link href={`/dashboard/events/${event.id}/orders`}>
+              <Button variant="outline">View Orders</Button>
+            </Link>
+            <Link href={`/events/${event.slug}`}>
+              <Button>Open Public Page</Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <p className="text-sm text-gray-500">Revenue</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{formatCurrency(stats.totalRevenue)}</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <p className="text-sm text-gray-500">Orders</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{stats.totalOrders}</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <p className="text-sm text-gray-500">Ticket Types</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{event._count.ticketTypes}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <SalesChart
+          title="Revenue by Ticket Type"
+          data={stats.ticketsByType.map((item) => ({ label: item.name, value: item.revenue }))}
+        />
+
+        <section className="rounded-xl border border-gray-200 bg-white p-6">
+          <h3 className="text-lg font-semibold text-gray-900">Order Summary</h3>
+          <ul className="mt-4 space-y-2 text-sm text-gray-700">
+            <li>Paid: {stats.paidOrders}</li>
+            <li>Pending invoice: {stats.pendingInvoiceOrders}</li>
+            <li>Cancelled: {stats.cancelledOrders}</li>
+            <li>Refunded: {stats.refundedOrders}</li>
+            <li>Total event orders: {event._count.orders}</li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/EventStatusBadge.tsx
+++ b/src/components/dashboard/EventStatusBadge.tsx
@@ -1,0 +1,20 @@
+import { EventStatus } from '@prisma/client'
+
+const statusStyles: Record<EventStatus, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700 border-gray-200',
+  PUBLISHED: 'bg-green-100 text-green-700 border-green-200',
+  CANCELLED: 'bg-red-100 text-red-700 border-red-200',
+  COMPLETED: 'bg-blue-100 text-blue-700 border-blue-200',
+}
+
+type EventStatusBadgeProps = {
+  status: EventStatus
+}
+
+export function EventStatusBadge({ status }: EventStatusBadgeProps) {
+  return (
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${statusStyles[status]}`}>
+      {status}
+    </span>
+  )
+}

--- a/src/components/dashboard/EventsTable.tsx
+++ b/src/components/dashboard/EventsTable.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import Link from 'next/link'
+import { EventStatus } from '@prisma/client'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { EventStatusBadge } from '@/components/dashboard/EventStatusBadge'
+import { formatDateTime } from '@/lib/utils'
+
+type EventsTableProps = {
+  events: Array<{
+    id: string
+    slug: string
+    title: string
+    startDate: Date
+    endDate: Date
+    status: EventStatus
+    visibility: 'PUBLIC' | 'PRIVATE'
+    _count: {
+      orders: number
+      ticketTypes: number
+    }
+  }>
+}
+
+export function EventsTable({ events }: EventsTableProps) {
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function runAction(eventId: string, action: 'publish' | 'cancel') {
+    setBusyId(eventId)
+    setError(null)
+
+    try {
+      const endpoint = action === 'publish' ? `/api/events/${eventId}/publish` : `/api/events/${eventId}/cancel`
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: action === 'cancel' ? JSON.stringify({}) : undefined,
+      })
+      const json = await response.json()
+      if (!response.ok) {
+        throw new Error(json?.error || `Failed to ${action} event`)
+      }
+      window.location.reload()
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : 'Action failed')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center text-gray-600">
+        No events match the current filters.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      {error ? <p className="border-b border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p> : null}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Event</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Date</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Orders</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Tickets</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-600">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {events.map((event) => (
+              <tr key={event.id}>
+                <td className="px-4 py-3">
+                  <p className="font-medium text-gray-900">{event.title}</p>
+                  <p className="text-xs text-gray-500">{event.visibility}</p>
+                </td>
+                <td className="px-4 py-3 text-gray-700">{formatDateTime(event.startDate)}</td>
+                <td className="px-4 py-3"><EventStatusBadge status={event.status} /></td>
+                <td className="px-4 py-3 text-gray-700">{event._count.orders}</td>
+                <td className="px-4 py-3 text-gray-700">{event._count.ticketTypes}</td>
+                <td className="px-4 py-3">
+                  <div className="flex justify-end gap-2">
+                    <Link href={`/dashboard/events/${event.id}/edit`}>
+                      <Button variant="outline" size="sm">Edit</Button>
+                    </Link>
+                    <Link href={`/dashboard/events/${event.id}`}>
+                      <Button variant="outline" size="sm">View</Button>
+                    </Link>
+                    {event.status === 'DRAFT' ? (
+                      <Button size="sm" isLoading={busyId === event.id} onClick={() => runAction(event.id, 'publish')}>
+                        Publish
+                      </Button>
+                    ) : null}
+                    {event.status === 'PUBLISHED' ? (
+                      <Button variant="destructive" size="sm" isLoading={busyId === event.id} onClick={() => runAction(event.id, 'cancel')}>
+                        Cancel
+                      </Button>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/OrderDetailView.tsx
+++ b/src/components/dashboard/OrderDetailView.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@/components/ui/button'
+import { formatCurrency, formatDateTime } from '@/lib/utils'
+
+type OrderDetailViewProps = {
+  order: {
+    id: string
+    orderNumber: string
+    status: string
+    paymentMethod: string | null
+    buyerFirstName: string
+    buyerLastName: string
+    buyerEmail: string
+    totalAmount: number
+    subtotal: number
+    discountAmount: number
+    currency: string
+    createdAt: Date
+    items: Array<{
+      id: string
+      quantity: number
+      unitPrice: number
+      totalPrice: number
+      ticketType: {
+        name: string
+      }
+    }>
+  }
+  refundAction: (formData: FormData) => Promise<void>
+  emailAction: (formData: FormData) => Promise<void>
+}
+
+export function OrderDetailView({ order, refundAction, emailAction }: OrderDetailViewProps) {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <h1 className="text-2xl font-bold text-gray-900">Order {order.orderNumber}</h1>
+        <p className="mt-1 text-sm text-gray-600">{order.status} · {order.paymentMethod || 'No payment method'} · {formatDateTime(order.createdAt)}</p>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-900">Buyer</h2>
+            <p className="text-sm text-gray-700">{order.buyerFirstName} {order.buyerLastName}</p>
+            <p className="text-sm text-gray-600">{order.buyerEmail}</p>
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-gray-900">Totals</h2>
+            <p className="text-sm text-gray-700">Subtotal: {formatCurrency(order.subtotal, order.currency)}</p>
+            <p className="text-sm text-gray-700">Discount: {formatCurrency(order.discountAmount, order.currency)}</p>
+            <p className="text-sm font-semibold text-gray-900">Total: {formatCurrency(order.totalAmount, order.currency)}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Tickets</h2>
+        <div className="mt-4 space-y-3">
+          {order.items.map((item) => (
+            <div key={item.id} className="rounded-lg border border-gray-100 p-3 text-sm">
+              <p className="font-medium text-gray-900">{item.ticketType.name}</p>
+              <p className="text-gray-600">Qty {item.quantity} × {formatCurrency(item.unitPrice, order.currency)} = {formatCurrency(item.totalPrice, order.currency)}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Actions</h2>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <form action={refundAction}>
+            <input type="hidden" name="orderId" value={order.id} />
+            <Button variant="outline" type="submit">Mark Refund Pending</Button>
+          </form>
+          <form action={emailAction}>
+            <input type="hidden" name="orderId" value={order.id} />
+            <Button type="submit">Send Email to Buyer</Button>
+          </form>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/dashboard/OrderFilters.tsx
+++ b/src/components/dashboard/OrderFilters.tsx
@@ -1,0 +1,59 @@
+import { OrderStatus, PaymentMethod } from '@prisma/client'
+
+type OrderFiltersProps = {
+  initial: {
+    search?: string
+    status?: OrderStatus | ''
+    paymentMethod?: PaymentMethod | ''
+    dateFrom?: string
+    dateTo?: string
+  }
+}
+
+export function OrderFilters({ initial }: OrderFiltersProps) {
+  return (
+    <form className="grid grid-cols-1 gap-3 rounded-xl border border-gray-200 bg-white p-4 md:grid-cols-6">
+      <div className="md:col-span-2">
+        <label htmlFor="search" className="text-xs font-medium text-gray-600">Search buyer / email / order #</label>
+        <input
+          id="search"
+          name="search"
+          defaultValue={initial.search || ''}
+          className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm"
+        />
+      </div>
+      <div>
+        <label htmlFor="status" className="text-xs font-medium text-gray-600">Status</label>
+        <select id="status" name="status" defaultValue={initial.status || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm">
+          <option value="">All</option>
+          <option value="PENDING">PENDING</option>
+          <option value="PENDING_INVOICE">PENDING_INVOICE</option>
+          <option value="PAID">PAID</option>
+          <option value="CANCELLED">CANCELLED</option>
+          <option value="REFUNDED">REFUNDED</option>
+          <option value="PARTIALLY_REFUNDED">PARTIALLY_REFUNDED</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="paymentMethod" className="text-xs font-medium text-gray-600">Payment</label>
+        <select id="paymentMethod" name="paymentMethod" defaultValue={initial.paymentMethod || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm">
+          <option value="">All</option>
+          <option value="PAYPAL">PAYPAL</option>
+          <option value="INVOICE">INVOICE</option>
+          <option value="FREE">FREE</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="dateFrom" className="text-xs font-medium text-gray-600">From</label>
+        <input id="dateFrom" name="dateFrom" type="date" defaultValue={initial.dateFrom || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm" />
+      </div>
+      <div>
+        <label htmlFor="dateTo" className="text-xs font-medium text-gray-600">To</label>
+        <input id="dateTo" name="dateTo" type="date" defaultValue={initial.dateTo || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm" />
+      </div>
+      <div className="md:col-span-6">
+        <button type="submit" className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white">Apply Filters</button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/dashboard/OrdersTable.tsx
+++ b/src/components/dashboard/OrdersTable.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import { OrderStatus, PaymentMethod } from '@prisma/client'
+import { formatCurrency, formatDateTime } from '@/lib/utils'
+
+type OrdersTableProps = {
+  eventId: string
+  orders: Array<{
+    id: string
+    orderNumber: string
+    buyerFirstName: string
+    buyerLastName: string
+    buyerEmail: string
+    status: OrderStatus
+    paymentMethod: PaymentMethod | null
+    totalAmount: number
+    currency: string
+    createdAt: Date
+  }>
+}
+
+export function OrdersTable({ eventId, orders }: OrdersTableProps) {
+  if (orders.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-600">
+        No orders found.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Order</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Buyer</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Payment</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Total</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-600">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {orders.map((order) => (
+              <tr key={order.id}>
+                <td className="px-4 py-3">
+                  <Link href={`/dashboard/events/${eventId}/orders/${order.id}`} className="font-medium text-blue-600 hover:text-blue-700">
+                    {order.orderNumber}
+                  </Link>
+                </td>
+                <td className="px-4 py-3 text-gray-700">
+                  {order.buyerFirstName} {order.buyerLastName}
+                  <p className="text-xs text-gray-500">{order.buyerEmail}</p>
+                </td>
+                <td className="px-4 py-3 text-gray-700">{order.status}</td>
+                <td className="px-4 py-3 text-gray-700">{order.paymentMethod || '-'}</td>
+                <td className="px-4 py-3 text-gray-900">{formatCurrency(order.totalAmount, order.currency)}</td>
+                <td className="px-4 py-3 text-gray-600">{formatDateTime(order.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/OrganizerProfileForm.tsx
+++ b/src/components/dashboard/OrganizerProfileForm.tsx
@@ -1,0 +1,58 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type OrganizerProfileFormProps = {
+  initial: {
+    orgName: string
+    description: string | null
+    logo: string | null
+    website: string | null
+    socialLinks: Record<string, string>
+  }
+  action: (formData: FormData) => Promise<void>
+}
+
+export function OrganizerProfileForm({ initial, action }: OrganizerProfileFormProps) {
+  return (
+    <form action={action} className="space-y-4 rounded-xl border border-gray-200 bg-white p-6">
+      <h1 className="text-2xl font-bold text-gray-900">Organizer Profile</h1>
+
+      <div>
+        <Label htmlFor="orgName" required>Organization Name</Label>
+        <Input id="orgName" name="orgName" defaultValue={initial.orgName} required />
+      </div>
+
+      <div>
+        <Label htmlFor="description">Description</Label>
+        <textarea
+          id="description"
+          name="description"
+          defaultValue={initial.description || ''}
+          className="min-h-24 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <Label htmlFor="website">Website</Label>
+          <Input id="website" name="website" defaultValue={initial.website || ''} />
+        </div>
+        <div>
+          <Label htmlFor="logo">Logo URL</Label>
+          <Input id="logo" name="logo" defaultValue={initial.logo || ''} />
+        </div>
+        <div>
+          <Label htmlFor="twitter">Twitter</Label>
+          <Input id="twitter" name="twitter" defaultValue={initial.socialLinks.twitter || ''} />
+        </div>
+        <div>
+          <Label htmlFor="linkedin">LinkedIn</Label>
+          <Input id="linkedin" name="linkedin" defaultValue={initial.socialLinks.linkedin || ''} />
+        </div>
+      </div>
+
+      <Button type="submit">Save Profile</Button>
+    </form>
+  )
+}

--- a/src/components/dashboard/RecentOrders.tsx
+++ b/src/components/dashboard/RecentOrders.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+import { OrderStatus } from '@prisma/client'
+import { formatCurrency, formatDateTime } from '@/lib/utils'
+
+type RecentOrdersProps = {
+  orders: Array<{
+    id: string
+    orderNumber: string
+    status: OrderStatus
+    totalAmount: number
+    currency: string
+    buyerEmail: string
+    createdAt: Date
+    event: {
+      id: string
+      title: string
+    }
+  }>
+}
+
+export function RecentOrders({ orders }: RecentOrdersProps) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Recent Orders</h2>
+      </div>
+
+      {orders.length === 0 ? (
+        <p className="text-sm text-gray-600">No orders yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {orders.map((order) => (
+            <div key={order.id} className="rounded-lg border border-gray-100 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <Link href={`/dashboard/events/${order.event.id}/orders/${order.id}`} className="font-medium text-gray-900 hover:text-blue-600">
+                  {order.orderNumber}
+                </Link>
+                <p className="text-sm font-medium text-gray-900">{formatCurrency(order.totalAmount, order.currency)}</p>
+              </div>
+              <p className="text-sm text-gray-600">{order.event.title}</p>
+              <p className="text-xs text-gray-500">{order.buyerEmail} · {order.status} · {formatDateTime(order.createdAt)}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/dashboard/SalesChart.tsx
+++ b/src/components/dashboard/SalesChart.tsx
@@ -1,0 +1,40 @@
+import { formatCurrency } from '@/lib/utils'
+
+type SalesChartProps = {
+  title?: string
+  data: Array<{
+    label: string
+    value: number
+  }>
+  currency?: string
+}
+
+export function SalesChart({ title = 'Sales Breakdown', data, currency = 'EUR' }: SalesChartProps) {
+  const maxValue = Math.max(...data.map((item) => item.value), 0)
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6">
+      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      {data.length === 0 ? (
+        <p className="mt-3 text-sm text-gray-600">No sales data yet.</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {data.map((item) => (
+            <div key={item.label}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="text-gray-700">{item.label}</span>
+                <span className="font-medium text-gray-900">{formatCurrency(item.value, currency)}</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+                <div
+                  className="h-full rounded-full bg-blue-600"
+                  style={{ width: `${maxValue === 0 ? 0 : (item.value / maxValue) * 100}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/dashboard/TicketTypeForm.tsx
+++ b/src/components/dashboard/TicketTypeForm.tsx
@@ -1,0 +1,79 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type TicketTypeFormProps = {
+  title: string
+  submitLabel: string
+  action: (formData: FormData) => Promise<void>
+  initial?: {
+    id: string
+    name: string
+    description: string | null
+    price: number
+    currency: string
+    maxCapacity: number | null
+    minPerOrder: number
+    maxPerOrder: number
+    isVisible: boolean
+  }
+}
+
+export function TicketTypeForm({ title, submitLabel, action, initial }: TicketTypeFormProps) {
+  return (
+    <form action={action} className="space-y-4 rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      {initial ? <input type="hidden" name="ticketTypeId" value={initial.id} /> : null}
+      <div>
+        <Label htmlFor={`${title}-name`} required>Name</Label>
+        <Input id={`${title}-name`} name="name" defaultValue={initial?.name || ''} required />
+      </div>
+      <div>
+        <Label htmlFor={`${title}-description`}>Description</Label>
+        <textarea
+          id={`${title}-description`}
+          name="description"
+          defaultValue={initial?.description || ''}
+          className="min-h-20 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <Label htmlFor={`${title}-price`} required>Price</Label>
+          <Input id={`${title}-price`} name="price" type="number" min="0" step="0.01" defaultValue={initial?.price ?? 0} required />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-currency`} required>Currency</Label>
+          <Input id={`${title}-currency`} name="currency" defaultValue={initial?.currency || 'EUR'} required />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-capacity`}>Max Capacity</Label>
+          <Input id={`${title}-capacity`} name="maxCapacity" type="number" min="1" defaultValue={initial?.maxCapacity ?? ''} placeholder="Leave empty for unlimited" />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-visible`}>Visibility</Label>
+          <select
+            id={`${title}-visible`}
+            name="isVisible"
+            defaultValue={initial?.isVisible === false ? 'false' : 'true'}
+            className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm"
+          >
+            <option value="true">Visible</option>
+            <option value="false">Hidden</option>
+          </select>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <Label htmlFor={`${title}-min`}>Min per Order</Label>
+          <Input id={`${title}-min`} name="minPerOrder" type="number" min="1" defaultValue={initial?.minPerOrder ?? 1} />
+        </div>
+        <div>
+          <Label htmlFor={`${title}-max`}>Max per Order</Label>
+          <Input id={`${title}-max`} name="maxPerOrder" type="number" min="1" defaultValue={initial?.maxPerOrder ?? 10} />
+        </div>
+      </div>
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  )
+}

--- a/src/components/dashboard/TicketTypeList.tsx
+++ b/src/components/dashboard/TicketTypeList.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@/components/ui/button'
+import { formatCurrency } from '@/lib/utils'
+
+type TicketTypeListProps = {
+  ticketTypes: Array<{
+    id: string
+    name: string
+    price: number
+    currency: string
+    soldCount: number
+    maxCapacity: number | null
+    isVisible: boolean
+  }>
+  deleteAction: (formData: FormData) => Promise<void>
+}
+
+export function TicketTypeList({ ticketTypes, deleteAction }: TicketTypeListProps) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6">
+      <h2 className="text-lg font-semibold text-gray-900">Ticket Types</h2>
+      {ticketTypes.length === 0 ? (
+        <p className="mt-3 text-sm text-gray-600">No ticket types configured.</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {ticketTypes.map((ticketType) => (
+            <div key={ticketType.id} className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 p-3">
+              <div>
+                <p className="font-medium text-gray-900">{ticketType.name}</p>
+                <p className="text-sm text-gray-600">
+                  {formatCurrency(ticketType.price, ticketType.currency)} · Sold: {ticketType.soldCount} · Capacity: {ticketType.maxCapacity ?? 'Unlimited'} · {ticketType.isVisible ? 'Visible' : 'Hidden'}
+                </p>
+              </div>
+              <form action={deleteAction}>
+                <input type="hidden" name="ticketTypeId" value={ticketType.id} />
+                <Button variant="destructive" size="sm">Delete</Button>
+              </form>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/dashboard/UpcomingEvents.tsx
+++ b/src/components/dashboard/UpcomingEvents.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+import { EventStatus } from '@prisma/client'
+import { EventStatusBadge } from '@/components/dashboard/EventStatusBadge'
+import { formatDateTime } from '@/lib/utils'
+
+type UpcomingEventsProps = {
+  events: Array<{
+    id: string
+    slug: string
+    title: string
+    startDate: Date
+    status: EventStatus
+  }>
+}
+
+export function UpcomingEvents({ events }: UpcomingEventsProps) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Upcoming Events</h2>
+        <Link href="/dashboard/events" className="text-sm text-blue-600 hover:text-blue-700">
+          View all
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <p className="text-sm text-gray-600">No upcoming events.</p>
+      ) : (
+        <div className="space-y-3">
+          {events.map((event) => (
+            <div key={event.id} className="rounded-lg border border-gray-100 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <Link href={`/dashboard/events/${event.id}`} className="font-medium text-gray-900 hover:text-blue-600">
+                  {event.title}
+                </Link>
+                <EventStatusBadge status={event.status} />
+              </div>
+              <p className="mt-1 text-sm text-gray-600">{formatDateTime(event.startDate)}</p>
+              <Link href={`/events/${event.slug}`} className="mt-1 inline-block text-xs text-gray-500 hover:text-gray-700">
+                Open public page
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/dashboard/organizer.ts
+++ b/src/lib/dashboard/organizer.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+
+export async function requireOrganizerProfile() {
+  const user = await requireRole('ORGANIZER')
+
+  const organizerProfile = await prisma.organizerProfile.findUnique({
+    where: { userId: user.id },
+    select: {
+      id: true,
+      orgName: true,
+      description: true,
+      logo: true,
+      website: true,
+      socialLinks: true,
+    },
+  })
+
+  if (!organizerProfile) {
+    throw new Error('Forbidden: Organizer profile not found')
+  }
+
+  return { user, organizerProfile }
+}


### PR DESCRIPTION
## Summary
- implement organizer dashboard home with stats, upcoming events, and recent orders
- add organizer statistics APIs (`/api/dashboard/statistics`, `/api/events/[id]/statistics`)
- add organizer event management pages (list, event dashboard, ticket/discount/order management, settings)
- add CSV export endpoint for event orders
- add reusable dashboard components (stats cards, tables, filters, forms, detail views)
- update `TASKS.md` to mark Org Admin (Developer 4) tasks as completed

## Validation
- `npm run lint` (passes with existing unrelated warnings)
- `npm run build` (passes)

## Notes
- dashboard routes are protected via organizer auth checks
- order detail actions include refund pending marker and buyer email trigger
