### PR TITLE
Add per-ticket attendee info and Excel export

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -356,6 +356,7 @@ model TicketType {
 
   event         Event              @relation(fields: [eventId], references: [id], onDelete: Cascade)
   orderItems    OrderItem[]
+  tickets       Ticket[]
   discountCodes DiscountCodeTicketType[]
 
   @@index([eventId])
@@ -495,6 +496,7 @@ model OrderItem {
   quantity     Int
   unitPrice    Decimal  @db.Decimal(10, 2)
   totalPrice   Decimal  @db.Decimal(10, 2)
+  attendeeData Json?    // Array of attendee info objects, one per ticket slot
   createdAt    DateTime @default(now())
 
   order      Order      @relation(fields: [orderId], references: [id], onDelete: Cascade)
@@ -510,9 +512,11 @@ model Ticket {
   ticketTypeId String
 
   // Attendee info (can be different from buyer)
-  attendeeFirstName String?
-  attendeeLastName  String?
-  attendeeEmail     String?
+  attendeeFirstName    String?
+  attendeeLastName     String?
+  attendeeEmail        String?
+  attendeeTitle        String?
+  attendeeOrganization String?
 
   status       TicketStatus @default(ACTIVE)
   checkedInAt  DateTime?
@@ -520,7 +524,8 @@ model Ticket {
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
 
-  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  order      Order      @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  ticketType TicketType @relation(fields: [ticketTypeId], references: [id], onDelete: Cascade)
 
   @@index([orderId])
   @@index([ticketCode])

--- a/src/app/api/dashboard/events/[id]/attendees/export-excel/route.ts
+++ b/src/app/api/dashboard/events/[id]/attendees/export-excel/route.ts
@@ -1,0 +1,202 @@
+import { NextResponse } from 'next/server'
+import { TicketStatus, Prisma } from '@prisma/client'
+import ExcelJS from 'exceljs'
+import { prisma } from '@/lib/db'
+import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+
+type RouteContext = {
+  params: Promise<{ id: string }>
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const { organizerProfile } = await requireOrganizerProfile()
+    const { id } = await context.params
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status') as TicketStatus | null
+
+    const event = await prisma.event.findFirst({
+      where: {
+        id,
+        organizerId: organizerProfile.id,
+      },
+      select: {
+        id: true,
+        title: true,
+        startDate: true,
+        timezone: true,
+        locationType: true,
+        venue: true,
+        city: true,
+        country: true,
+        onlineUrl: true,
+      },
+    })
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const where: Prisma.TicketWhereInput = {
+      order: {
+        eventId: id,
+        status: { in: ['PAID', 'PENDING_INVOICE'] },
+      },
+    }
+
+    if (status && ['ACTIVE', 'CANCELLED', 'USED'].includes(status)) {
+      where.status = status
+    }
+
+    const tickets = await prisma.ticket.findMany({
+      where,
+      select: {
+        ticketCode: true,
+        attendeeFirstName: true,
+        attendeeLastName: true,
+        attendeeEmail: true,
+        attendeeTitle: true,
+        attendeeOrganization: true,
+        status: true,
+        checkedInAt: true,
+        ticketType: {
+          select: {
+            name: true,
+            price: true,
+            currency: true,
+          },
+        },
+        order: {
+          select: {
+            orderNumber: true,
+            createdAt: true,
+            buyerFirstName: true,
+            buyerLastName: true,
+            buyerEmail: true,
+            buyerCity: true,
+            buyerCountry: true,
+            currency: true,
+          },
+        },
+      },
+      orderBy: [
+        { order: { createdAt: 'asc' } },
+        { createdAt: 'asc' },
+      ],
+    })
+
+    // Build Excel workbook
+    const workbook = new ExcelJS.Workbook()
+    const sheet = workbook.addWorksheet('Attendees')
+
+    // Column headers matching the reference format
+    sheet.columns = [
+      { header: 'Order ID', key: 'orderId', width: 20 },
+      { header: 'Order date', key: 'orderDate', width: 22 },
+      { header: 'Attendee first name', key: 'attendeeFirstName', width: 20 },
+      { header: 'Attendee last name', key: 'attendeeLastName', width: 20 },
+      { header: 'Attendee email', key: 'attendeeEmail', width: 30 },
+      { header: 'Phone number', key: 'phoneNumber', width: 15 },
+      { header: 'Purchaser city', key: 'purchaserCity', width: 18 },
+      { header: 'Purchaser state', key: 'purchaserState', width: 18 },
+      { header: 'Purchaser country', key: 'purchaserCountry', width: 18 },
+      { header: 'Event name', key: 'eventName', width: 30 },
+      { header: 'Event ID', key: 'eventId', width: 20 },
+      { header: 'Event start date', key: 'eventStartDate', width: 16 },
+      { header: 'Event start time', key: 'eventStartTime', width: 16 },
+      { header: 'Event timezone', key: 'eventTimezone', width: 20 },
+      { header: 'Event location', key: 'eventLocation', width: 25 },
+      { header: 'Ticket quantity', key: 'ticketQuantity', width: 15 },
+      { header: 'Ticket tier', key: 'ticketTier', width: 15 },
+      { header: 'Ticket type', key: 'ticketType', width: 25 },
+      { header: 'Currency', key: 'currency', width: 10 },
+      { header: 'Ticket price', key: 'ticketPrice', width: 14 },
+      { header: 'Buyer first name', key: 'buyerFirstName', width: 18 },
+      { header: 'Buyer last name', key: 'buyerLastName', width: 18 },
+      { header: 'Buyer email', key: 'buyerEmail', width: 30 },
+      { header: 'Seating location 1', key: 'seating1', width: 18 },
+      { header: 'Seating location 2', key: 'seating2', width: 18 },
+      { header: 'Seating location 3', key: 'seating3', width: 18 },
+      { header: 'Barcode number', key: 'barcodeNumber', width: 28 },
+      { header: 'Guest', key: 'guest', width: 8 },
+    ]
+
+    // Style header row
+    sheet.getRow(1).font = { bold: true }
+
+    // Format event date/time
+    const eventStartDate = event.startDate.toISOString().split('T')[0]
+    const eventStartTime = event.startDate.toTimeString().split(' ')[0]
+    const eventLocation =
+      event.locationType === 'ONLINE'
+        ? event.onlineUrl || 'Online'
+        : [event.venue, event.city, event.country].filter(Boolean).join(', ')
+
+    for (const ticket of tickets) {
+      const attendeeFirstName = ticket.attendeeFirstName || ticket.order.buyerFirstName
+      const attendeeLastName = ticket.attendeeLastName || ticket.order.buyerLastName
+      const attendeeEmail = ticket.attendeeEmail || ticket.order.buyerEmail
+
+      const orderDate = ticket.order.createdAt.toISOString().replace('T', ' ').substring(0, 19)
+
+      sheet.addRow({
+        orderId: ticket.order.orderNumber,
+        orderDate,
+        attendeeFirstName,
+        attendeeLastName,
+        attendeeEmail,
+        phoneNumber: '',
+        purchaserCity: ticket.order.buyerCity || '',
+        purchaserState: '',
+        purchaserCountry: ticket.order.buyerCountry || '',
+        eventName: event.title,
+        eventId: event.id,
+        eventStartDate,
+        eventStartTime,
+        eventTimezone: event.timezone,
+        eventLocation,
+        ticketQuantity: 1,
+        ticketTier: '',
+        ticketType: ticket.ticketType.name,
+        currency: ticket.order.currency,
+        ticketPrice: Number(ticket.ticketType.price).toFixed(2),
+        buyerFirstName: ticket.order.buyerFirstName,
+        buyerLastName: ticket.order.buyerLastName,
+        buyerEmail: ticket.order.buyerEmail,
+        seating1: '',
+        seating2: '',
+        seating3: '',
+        barcodeNumber: ticket.ticketCode,
+        guest: 'No',
+      })
+    }
+
+    const buffer = await workbook.xlsx.writeBuffer()
+
+    const safeTitle = event.title
+      .replace(/[^a-zA-Z0-9]/g, '-')
+      .replace(/-+/g, '-')
+      .substring(0, 50)
+
+    return new NextResponse(buffer as ArrayBuffer, {
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${safeTitle}-attendees.xlsx"`,
+      },
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Unauthorized') {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      if (error.message.includes('Forbidden')) {
+        return NextResponse.json({ error: error.message }, { status: 403 })
+      }
+    }
+
+    console.error('Attendee Excel export failed:', error)
+    return NextResponse.json({ error: 'Failed to export attendees' }, { status: 500 })
+  }
+}

--- a/src/app/api/dashboard/events/[id]/attendees/export/route.ts
+++ b/src/app/api/dashboard/events/[id]/attendees/export/route.ts
@@ -54,6 +54,8 @@ export async function GET(request: Request, context: RouteContext) {
         attendeeFirstName: true,
         attendeeLastName: true,
         attendeeEmail: true,
+        attendeeTitle: true,
+        attendeeOrganization: true,
         status: true,
         checkedInAt: true,
         order: {
@@ -91,9 +93,8 @@ export async function GET(request: Request, context: RouteContext) {
       const firstName = ticket.attendeeFirstName || ticket.order.buyerFirstName
       const lastName = ticket.attendeeLastName || ticket.order.buyerLastName
       const email = ticket.attendeeEmail || ticket.order.buyerEmail
-      // Title and organization come from buyer info (not stored on attendee)
-      const title = ticket.order.buyerTitle || ''
-      const organization = ticket.order.buyerOrganization || ''
+      const title = ticket.attendeeTitle || ticket.order.buyerTitle || ''
+      const organization = ticket.attendeeOrganization || ticket.order.buyerOrganization || ''
 
       lines.push([
         csvCell(ticket.ticketCode),

--- a/src/app/api/orders/[id]/capture/route.ts
+++ b/src/app/api/orders/[id]/capture/route.ts
@@ -175,6 +175,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             unitPrice: Number(item.unitPrice),
             totalPrice: Number(item.totalPrice),
             currency: latestOrder.currency,
+            attendees: Array.isArray(item.attendeeData) ? (item.attendeeData as unknown as import('@/lib/orders').AttendeeData[]) : undefined,
           }))
         )
 

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -223,6 +223,13 @@ export async function POST(request: NextRequest) {
           },
         })
 
+        // Build a map of attendee data from the request, keyed by ticketTypeId
+        const attendeesByTicketType = new Map(
+          input.items
+            .filter((item) => item.attendees && item.attendees.length > 0)
+            .map((item) => [item.ticketTypeId, item.attendees!])
+        )
+
         if (preparedOrder.items.length > 0) {
           await tx.orderItem.createMany({
             data: preparedOrder.items.map((item) => ({
@@ -231,6 +238,7 @@ export async function POST(request: NextRequest) {
               quantity: item.quantity,
               unitPrice: item.unitPrice,
               totalPrice: item.totalPrice,
+              attendeeData: attendeesByTicketType.get(item.ticketTypeId) ?? undefined,
             })),
           })
         }
@@ -247,7 +255,13 @@ export async function POST(request: NextRequest) {
             })
           }
 
-          const tickets = generateTicketCreateInput(order.id, preparedOrder.items)
+          const tickets = generateTicketCreateInput(
+            order.id,
+            preparedOrder.items.map((item) => ({
+              ...item,
+              attendees: attendeesByTicketType.get(item.ticketTypeId),
+            }))
+          )
           if (tickets.length > 0) {
             await tx.ticket.createMany({ data: tickets })
           }

--- a/src/app/api/webhooks/paypal/route.ts
+++ b/src/app/api/webhooks/paypal/route.ts
@@ -220,6 +220,7 @@ async function handleCaptureCompleted(event: PayPalWebhookEvent) {
           unitPrice: Number(item.unitPrice),
           totalPrice: Number(item.totalPrice),
           currency: latestOrder.currency,
+          attendees: Array.isArray(item.attendeeData) ? (item.attendeeData as unknown as import('@/lib/orders').AttendeeData[]) : undefined,
         }))
       )
 

--- a/src/components/dashboard/EventDashboard.tsx
+++ b/src/components/dashboard/EventDashboard.tsx
@@ -71,7 +71,13 @@ export function EventDashboard({ event, stats }: EventDashboardProps) {
             <a href={`/api/dashboard/events/${event.id}/attendees/export`} download>
               <Button variant="outline">
                 <Download className="mr-2 h-4 w-4" />
-                Export Attendees
+                Export CSV
+              </Button>
+            </a>
+            <a href={`/api/dashboard/events/${event.id}/attendees/export-excel`} download>
+              <Button variant="outline">
+                <Download className="mr-2 h-4 w-4" />
+                Export Excel
               </Button>
             </a>
             <Link href={`/events/${event.slug}`}>

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -32,6 +32,18 @@ interface BuyerFormState {
   country: string
 }
 
+interface AttendeeFormState {
+  firstName: string
+  lastName: string
+  email: string
+  title: string
+  organization: string
+}
+
+function emptyAttendee(): AttendeeFormState {
+  return { firstName: '', lastName: '', email: '', title: '', organization: '' }
+}
+
 function calculateDiscountAmount(
   subtotal: number,
   discount: AppliedDiscount | null,
@@ -74,10 +86,11 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isRedirecting, setIsRedirecting] = useState(false)
 
-  // Check if user returned from cancelled PayPal payment
+  // Map of ticketTypeId -> AttendeeFormState[]
+  const [attendeesByType, setAttendeesByType] = useState<Record<string, AttendeeFormState[]>>({})
+
   const wasCancelled = searchParams.get('cancelled') === 'true'
 
-  // Check if user is authenticated
   const isAuthenticated = status === 'authenticated'
   const isLoadingAuth = status === 'loading'
 
@@ -166,6 +179,65 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
     [selectedItems]
   )
 
+  // Keep attendeesByType in sync when quantities change
+  useEffect(() => {
+    setAttendeesByType((current) => {
+      const updated: Record<string, AttendeeFormState[]> = {}
+
+      for (const item of selectedItems) {
+        const existing = current[item.ticketTypeId] ?? []
+        const needed = item.quantity
+
+        if (existing.length >= needed) {
+          // Trim extras
+          updated[item.ticketTypeId] = existing.slice(0, needed)
+        } else {
+          // Add empty slots for new tickets
+          const added = Array.from({ length: needed - existing.length }, emptyAttendee)
+          updated[item.ticketTypeId] = [...existing, ...added]
+        }
+      }
+
+      return updated
+    })
+  }, [selectedItems])
+
+  // Pre-fill first attendee slot of the first ticket type with buyer info
+  useEffect(() => {
+    if (selectedItems.length === 0) return
+
+    const firstTypeId = selectedItems[0].ticketTypeId
+
+    setAttendeesByType((current) => {
+      const slots = current[firstTypeId]
+      if (!slots || slots.length === 0) return current
+
+      // Only auto-update if the slot looks empty or still matches old buyer info
+      const first = slots[0]
+      const looksUnedited =
+        first.firstName === '' ||
+        first.firstName === buyer.firstName
+
+      if (!looksUnedited) return current
+
+      return {
+        ...current,
+        [firstTypeId]: [
+          {
+            ...first,
+            firstName: buyer.firstName,
+            lastName: buyer.lastName,
+            email: buyer.email,
+            title: buyer.title,
+            organization: buyer.organization,
+          },
+          ...slots.slice(1),
+        ],
+      }
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buyer.firstName, buyer.lastName, buyer.email, buyer.title, buyer.organization])
+
   useEffect(() => {
     if (discount?.discountType === 'INVOICE') {
       setPaymentMethod('INVOICE')
@@ -186,6 +258,20 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
     }))
   }
 
+  function updateAttendeeField(
+    ticketTypeId: string,
+    index: number,
+    field: keyof AttendeeFormState,
+    value: string
+  ) {
+    setAttendeesByType((current) => {
+      const slots = current[ticketTypeId] ? [...current[ticketTypeId]] : []
+      if (!slots[index]) return current
+      slots[index] = { ...slots[index], [field]: value }
+      return { ...current, [ticketTypeId]: slots }
+    })
+  }
+
   async function handleSubmit(eventForm: FormEvent<HTMLFormElement>) {
     eventForm.preventDefault()
 
@@ -197,6 +283,19 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
     if (!buyer.firstName || !buyer.lastName || !buyer.email) {
       setSubmitError('First name, last name, and email are required')
       return
+    }
+
+    // Validate all attendee slots are filled
+    for (const item of selectedItems) {
+      const slots = attendeesByType[item.ticketTypeId] ?? []
+      for (let i = 0; i < item.quantity; i++) {
+        const a = slots[i]
+        if (!a || !a.firstName || !a.lastName || !a.email) {
+          const ticketName = ticketTypes.find((t) => t.id === item.ticketTypeId)?.name ?? 'ticket'
+          setSubmitError(`Please fill in all attendee details for "${ticketName}" (ticket ${i + 1})`)
+          return
+        }
+      }
     }
 
     setIsSubmitting(true)
@@ -213,6 +312,7 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
           items: selectedItems.map((item) => ({
             ticketTypeId: item.ticketTypeId,
             quantity: item.quantity,
+            attendees: (attendeesByType[item.ticketTypeId] ?? []).slice(0, item.quantity),
           })),
           buyer,
           discountCode: discount?.code,
@@ -248,7 +348,6 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
         // Check if PayPal redirect is needed
         if (payData.checkout?.type === 'redirect' && payData.checkout?.approvalUrl) {
           setIsRedirecting(true)
-          // Redirect to PayPal for payment approval
           window.location.href = payData.checkout.approvalUrl
           return
         }
@@ -446,6 +545,120 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
             </div>
           </CardContent>
         </Card>
+
+        {/* Per-ticket attendee information */}
+        {selectedItems.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Attendee Information</CardTitle>
+              <p className="text-sm text-gray-500">
+                Please provide details for each ticket holder. The first ticket is pre-filled with your buyer information.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {selectedItems.map((item) => {
+                const ticketType = ticketTypes.find((t) => t.id === item.ticketTypeId)
+                const slots = attendeesByType[item.ticketTypeId] ?? []
+
+                return (
+                  <div key={item.ticketTypeId} className="space-y-4">
+                    {Array.from({ length: item.quantity }, (_, i) => {
+                      const attendee = slots[i] ?? emptyAttendee()
+                      const label =
+                        item.quantity > 1
+                          ? `${ticketType?.name ?? 'Ticket'} #${i + 1}`
+                          : (ticketType?.name ?? 'Ticket')
+
+                      return (
+                        <div
+                          key={`${item.ticketTypeId}-${i}`}
+                          className="rounded-lg border border-gray-200 p-4"
+                        >
+                          <p className="mb-3 text-sm font-medium text-gray-700">{label}</p>
+                          <div className="grid gap-3 sm:grid-cols-2">
+                            <div className="space-y-1">
+                              <Label
+                                htmlFor={`attendee-${item.ticketTypeId}-${i}-first-name`}
+                                required
+                              >
+                                First Name
+                              </Label>
+                              <Input
+                                id={`attendee-${item.ticketTypeId}-${i}-first-name`}
+                                value={attendee.firstName}
+                                onChange={(e) =>
+                                  updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
+                                }
+                                required
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label
+                                htmlFor={`attendee-${item.ticketTypeId}-${i}-last-name`}
+                                required
+                              >
+                                Last Name
+                              </Label>
+                              <Input
+                                id={`attendee-${item.ticketTypeId}-${i}-last-name`}
+                                value={attendee.lastName}
+                                onChange={(e) =>
+                                  updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
+                                }
+                                required
+                              />
+                            </div>
+                            <div className="space-y-1 sm:col-span-2">
+                              <Label
+                                htmlFor={`attendee-${item.ticketTypeId}-${i}-email`}
+                                required
+                              >
+                                Email
+                              </Label>
+                              <Input
+                                id={`attendee-${item.ticketTypeId}-${i}-email`}
+                                type="email"
+                                value={attendee.email}
+                                onChange={(e) =>
+                                  updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
+                                }
+                                required
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-title`}>
+                                Title
+                              </Label>
+                              <Input
+                                id={`attendee-${item.ticketTypeId}-${i}-title`}
+                                value={attendee.title}
+                                onChange={(e) =>
+                                  updateAttendeeField(item.ticketTypeId, i, 'title', e.target.value)
+                                }
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-organization`}>
+                                Organization
+                              </Label>
+                              <Input
+                                id={`attendee-${item.ticketTypeId}-${i}-organization`}
+                                value={attendee.organization}
+                                onChange={(e) =>
+                                  updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
+                                }
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )
+              })}
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       <div className="space-y-6 lg:col-span-1">

--- a/src/lib/orders/index.ts
+++ b/src/lib/orders/index.ts
@@ -2,9 +2,18 @@ import { Prisma } from '@prisma/client'
 import { generateTicketCode } from '@/lib/utils'
 import { decimalToNumber, toMoneyCents, fromMoneyCents } from '@/lib/tickets'
 
+export interface AttendeeData {
+  firstName: string
+  lastName: string
+  email: string
+  title?: string
+  organization?: string
+}
+
 export interface RequestedOrderItem {
   ticketTypeId: string
   quantity: number
+  attendees?: AttendeeData[]
 }
 
 export interface PreparedOrderItem {
@@ -87,19 +96,34 @@ export function prepareOrderItems(
   }
 }
 
-export function generateTicketCreateInput(orderId: string, items: PreparedOrderItem[]) {
+export interface PreparedOrderItemWithAttendees extends PreparedOrderItem {
+  attendees?: AttendeeData[]
+}
+
+export function generateTicketCreateInput(orderId: string, items: PreparedOrderItemWithAttendees[]) {
   const tickets: Array<{
     ticketCode: string
     orderId: string
     ticketTypeId: string
+    attendeeFirstName?: string
+    attendeeLastName?: string
+    attendeeEmail?: string
+    attendeeTitle?: string
+    attendeeOrganization?: string
   }> = []
 
   for (const item of items) {
     for (let i = 0; i < item.quantity; i += 1) {
+      const attendee = item.attendees?.[i]
       tickets.push({
         ticketCode: generateTicketCode(),
         orderId,
         ticketTypeId: item.ticketTypeId,
+        attendeeFirstName: attendee?.firstName,
+        attendeeLastName: attendee?.lastName,
+        attendeeEmail: attendee?.email,
+        attendeeTitle: attendee?.title,
+        attendeeOrganization: attendee?.organization,
       })
     }
   }

--- a/src/lib/validations/order.ts
+++ b/src/lib/validations/order.ts
@@ -12,9 +12,18 @@ export const buyerInfoSchema = z.object({
   country: z.string().optional(),
 })
 
+export const checkoutAttendeeSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  email: z.string().email('Invalid email address'),
+  title: z.string().optional(),
+  organization: z.string().optional(),
+})
+
 export const orderItemSchema = z.object({
   ticketTypeId: z.string().min(1),
   quantity: z.number().int().min(1, 'Quantity must be at least 1'),
+  attendees: z.array(checkoutAttendeeSchema).optional(),
 })
 
 export const createOrderSchema = z.object({
@@ -43,6 +52,7 @@ export const attendeeInfoSchema = z.object({
 })
 
 export type BuyerInfoInput = z.infer<typeof buyerInfoSchema>
+export type CheckoutAttendeeInput = z.infer<typeof checkoutAttendeeSchema>
 export type OrderItemInput = z.infer<typeof orderItemSchema>
 export type CreateOrderInput = z.infer<typeof createOrderSchema>
 export type CancelOrderInput = z.infer<typeof cancelOrderSchema>


### PR DESCRIPTION
## Changes

### Database Schema
- Add `attendeeData` JSON field to `OrderItem` to store attendee information
- Add `attendeeTitle` and `attendeeOrganization` fields to `Ticket` model
- Add relationship between `Ticket` and `TicketType`

### Checkout Flow
- Add per-ticket attendee information form in `CheckoutForm`
- Support collecting first name, last name, email, title, and organization for each ticket
- Auto-fill first ticket slot with buyer information
- Validate all attendee slots are filled before submission
- Pass attendee data through order creation API

### Order Processing
- Store attendee data in `OrderItem.attendeeData`
- Populate `Ticket` records with individual attendee details
- Support attendee data in PayPal capture and webhook handlers

### Attendee Export
- Add new Excel export endpoint with comprehensive formatting
- Update CSV export to use per-ticket attendee fields (title, organization)
- Add "Export Excel" button to event dashboard

### Validation
- Add `checkoutAttendeeSchema` for attendee field validation
- Update `orderItemSchema` to include optional attendees array