### PR TITLE
feat: make invoices available upon request (#196)

### DIFF
--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -862,7 +862,7 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
             <CardHeader>
               <CardTitle className="text-lg">Payment Method</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-2">
+            <CardContent className="space-y-3">
               <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
                 <input
                   type="radio"
@@ -874,21 +874,34 @@ export function CheckoutForm({ event }: CheckoutFormProps) {
                 />
                 PayPal
               </label>
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
-                <input
-                  type="radio"
-                  name="payment-method"
-                  value="INVOICE"
-                  checked={paymentMethod === 'INVOICE'}
-                  onChange={() => setPaymentMethod('INVOICE')}
-                />
-                Invoice
-              </label>
+              {/* Only show invoice option when an invoice-enabling discount code is applied */}
+              {discount?.discountType === 'INVOICE' && (
+                <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="radio"
+                    name="payment-method"
+                    value="INVOICE"
+                    checked={paymentMethod === 'INVOICE'}
+                    onChange={() => setPaymentMethod('INVOICE')}
+                  />
+                  Invoice
+                </label>
+              )}
               {discount?.discountType === 'INVOICE' && (
                 <p className="text-xs text-gray-500">Invoice code applied. Checkout will create a pending invoice order.</p>
               )}
               {discount?.discountType === 'FREE_TICKET' && (
                 <p className="text-xs text-green-600">Free ticket code applied. No payment required.</p>
+              )}
+              {/* Informational text about invoice payment */}
+              {discount?.discountType !== 'INVOICE' && (
+                <p className="mt-2 text-xs text-gray-500">
+                  Want to pay by invoice? Contact{' '}
+                  <a href="mailto:info@eyevinn.se" className="text-blue-600 hover:underline">
+                    info@eyevinn.se
+                  </a>{' '}
+                  to request invoice payment.
+                </p>
               )}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

- Hides the invoice payment option in checkout by default
- Invoice payment is now only available when a special INVOICE-type discount code is applied
- Adds informational text directing users to contact info@eyevinn.se to request invoice payment

## Details

This addresses issue #196 where attendees should only see the "Pay by Invoice" option after entering a special promo code.

### How it works:
1. Organizers create a discount code of type `INVOICE` (this already exists in the system)
2. Users contact info@eyevinn.se to request invoice payment
3. Eyevinn provides them with the special invoice code
4. When users apply the code at checkout, the Invoice payment option appears

### Changes:
- `src/components/tickets/CheckoutForm.tsx`:
  - Invoice radio button is now conditionally rendered only when `discount?.discountType === 'INVOICE'`
  - Added informational text: "Want to pay by invoice? Contact info@eyevinn.se to request invoice payment."

## Test plan

- [ ] Go to checkout without any discount code applied
  - [ ] Verify only PayPal is shown as payment option
  - [ ] Verify informational text about contacting info@eyevinn.se is displayed
- [ ] Create an INVOICE type discount code for an event
- [ ] Apply the INVOICE discount code at checkout
  - [ ] Verify Invoice payment option now appears
  - [ ] Verify informational text is hidden when invoice code is applied
  - [ ] Verify Invoice is auto-selected when the code is applied
- [ ] Complete an order using the invoice payment method

Closes #196