### PR TITLE
feat: improve invoice order messaging and conditional ticket download

### DIFF
--- a/src/app/(public)/orders/[orderNumber]/page.tsx
+++ b/src/app/(public)/orders/[orderNumber]/page.tsx
@@ -7,6 +7,25 @@ interface ConfirmationPageProps {
   params: Promise<{ orderNumber: string }>
 }
 
+function getPageTitle(status: string, paymentMethod: string | null): string {
+  if (status === 'PENDING_INVOICE') {
+    return 'Invoice Order Received'
+  }
+  if (status === 'PAID') {
+    return 'Order Confirmed'
+  }
+  if (status === 'PENDING' && paymentMethod === 'INVOICE') {
+    return 'Invoice Order Received'
+  }
+  if (status === 'CANCELLED') {
+    return 'Order Cancelled'
+  }
+  if (status === 'REFUNDED' || status === 'PARTIALLY_REFUNDED') {
+    return 'Order Refunded'
+  }
+  return 'Order Details'
+}
+
 export default async function OrderConfirmationPage({ params }: ConfirmationPageProps) {
   const user = await getCurrentUser()
 
@@ -56,9 +75,11 @@ export default async function OrderConfirmationPage({ params }: ConfirmationPage
     notFound()
   }
 
+  const pageTitle = getPageTitle(order.status, order.paymentMethod)
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">Order Confirmation</h1>
+      <h1 className="mb-6 text-2xl font-bold text-gray-900">{pageTitle}</h1>
       <TicketDisplay order={order} />
     </div>
   )

--- a/src/components/tickets/TicketDisplay.tsx
+++ b/src/components/tickets/TicketDisplay.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { CalendarPlus, ExternalLink, CreditCard } from 'lucide-react'
+import { ExternalLink, CreditCard, Clock, CheckCircle } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { formatDateTime } from '@/lib/utils'
 import { DownloadTicketsButton } from '@/components/tickets/DownloadTicketsButton'
@@ -69,6 +69,8 @@ export function TicketDisplay({ order }: TicketDisplayProps) {
       : [order.event.venue, order.event.city, order.event.country].filter(Boolean).join(', ')
 
   const isPendingInvoice = order.status === 'PENDING_INVOICE'
+  const isPaid = order.status === 'PAID'
+  const canDownloadTickets = isPaid && order.tickets.length > 0
   const statusDisplay = getStatusDisplay(order.status)
 
   const calendarStart = new Date(order.event.startDate).toISOString().replace(/[-:]|\.\d{3}/g, '')
@@ -121,7 +123,7 @@ export function TicketDisplay({ order }: TicketDisplayProps) {
                 endDate: order.event.endDate,
               }}
             />
-            <DownloadTicketsButton />
+            {canDownloadTickets && <DownloadTicketsButton />}
           </div>
         </CardContent>
       </Card>
@@ -131,13 +133,42 @@ export function TicketDisplay({ order }: TicketDisplayProps) {
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg text-yellow-800">
               <CreditCard className="h-5 w-5" />
-              Payment Instructions
+              Payment Required
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4 text-sm">
-            <p className="text-yellow-800">
-              Your order has been received and is awaiting payment. Please complete your payment to receive your tickets.
-            </p>
+            {/* Status Progression */}
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-yellow-200 bg-white p-3">
+              <div className="flex items-center gap-1.5">
+                <CheckCircle className="h-4 w-4 text-green-600" />
+                <span className="text-xs font-medium text-green-700">Order Received</span>
+              </div>
+              <div className="hidden h-0.5 w-4 bg-yellow-300 sm:block" />
+              <div className="flex items-center gap-1.5">
+                <Clock className="h-4 w-4 text-yellow-600" />
+                <span className="text-xs font-medium text-yellow-700">Awaiting Payment</span>
+              </div>
+              <div className="hidden h-0.5 w-4 bg-gray-200 sm:block" />
+              <div className="flex items-center gap-1.5 opacity-50">
+                <CheckCircle className="h-4 w-4 text-gray-400" />
+                <span className="text-xs font-medium text-gray-400">Tickets Issued</span>
+              </div>
+            </div>
+
+            <div className="space-y-2 text-yellow-800">
+              <p>
+                Your order has been received. Please complete payment to receive your tickets.
+              </p>
+              <p className="font-medium">
+                What happens next:
+              </p>
+              <ol className="ml-4 list-decimal space-y-1 text-sm">
+                <li>Pay the invoice using the details below</li>
+                <li>The organizer confirms your payment</li>
+                <li>Your tickets will be issued and available for download</li>
+              </ol>
+            </div>
+
             <div className="rounded-md border border-yellow-200 bg-white p-4">
               <h4 className="mb-2 font-semibold text-gray-900">Payment Details</h4>
               <dl className="space-y-1 text-gray-700">
@@ -153,7 +184,6 @@ export function TicketDisplay({ order }: TicketDisplayProps) {
             </div>
             <p className="text-xs text-yellow-700">
               Please include your order number ({order.orderNumber}) as the payment reference.
-              Your tickets will be issued once payment is confirmed by the event organizer.
             </p>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Add dynamic page titles based on order status (e.g., "Invoice Order Received" for pending invoice orders, "Order Confirmed" for paid orders)
- Hide download tickets button for unpaid invoice orders until payment is confirmed
- Add visual status progression indicator showing Order Received -> Awaiting Payment -> Tickets Issued
- Improve payment instructions with clear next steps for invoice payment

## Changes
- `src/app/(public)/orders/[orderNumber]/page.tsx`: Add `getPageTitle()` function to display context-appropriate titles
- `src/components/tickets/TicketDisplay.tsx`: 
  - Conditionally show download button only for paid orders with tickets
  - Add status progression UI with icons
  - Rename "Payment Instructions" to "Payment Required"
  - Add numbered steps explaining what happens next

## Test plan
- [ ] Navigate to an order confirmation page for a PAID order - should show "Order Confirmed" title and download button
- [ ] Navigate to an order confirmation page for a PENDING_INVOICE order - should show "Invoice Order Received" title, no download button, and status progression
- [ ] Navigate to an order confirmation page for a CANCELLED order - should show "Order Cancelled" title
- [ ] Verify the status progression indicator shows correctly on mobile (responsive)

Closes #152