### PR TITLE
feat: make organization mandatory and add to Excel export

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -88,17 +88,8 @@ export default async function DashboardHomePage() {
 
   const welcomeName = organizerProfile?.orgName || user.name || 'Admin'
 
-  const resolvedAppUrl = process.env.PUBLIC_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-
   return (
     <div className="space-y-6">
-      {/* DEBUG: remove after verifying payment redirect URLs */}
-      <div className="rounded bg-yellow-100 border border-yellow-400 px-4 py-2 text-sm text-yellow-800">
-        <strong>DEBUG</strong> — Resolved APP_URL: <code>{resolvedAppUrl}</code>
-        <span className="ml-2 text-xs text-yellow-600">
-          (PUBLIC_URL={process.env.PUBLIC_URL ?? 'unset'}, NEXT_PUBLIC_APP_URL={process.env.NEXT_PUBLIC_APP_URL ?? 'unset'})
-        </span>
-      </div>
       <WorkspacePageHeader
         title={`Welcome, ${welcomeName}`}
         description="Platform-wide overview of events, orders, and revenue."

--- a/src/app/api/dashboard/events/[id]/attendees/export-excel/route.ts
+++ b/src/app/api/dashboard/events/[id]/attendees/export-excel/route.ts
@@ -72,6 +72,7 @@ export async function GET(request: Request, context: RouteContext) {
             buyerFirstName: true,
             buyerLastName: true,
             buyerEmail: true,
+            buyerOrganization: true,
             buyerCity: true,
             buyerCountry: true,
             currency: true,
@@ -95,6 +96,7 @@ export async function GET(request: Request, context: RouteContext) {
       { header: 'Attendee first name', key: 'attendeeFirstName', width: 20 },
       { header: 'Attendee last name', key: 'attendeeLastName', width: 20 },
       { header: 'Attendee email', key: 'attendeeEmail', width: 30 },
+      { header: 'Organization', key: 'organization', width: 25 },
       { header: 'Phone number', key: 'phoneNumber', width: 15 },
       { header: 'Purchaser city', key: 'purchaserCity', width: 18 },
       { header: 'Purchaser state', key: 'purchaserState', width: 18 },
@@ -137,6 +139,7 @@ export async function GET(request: Request, context: RouteContext) {
       const attendeeFirstName = ticket.attendeeFirstName || ticket.order.buyerFirstName
       const attendeeLastName = ticket.attendeeLastName || ticket.order.buyerLastName
       const attendeeEmail = ticket.attendeeEmail || ticket.order.buyerEmail
+      const organization = ticket.attendeeOrganization || ticket.order.buyerOrganization || ''
 
       const orderDate = ticket.order.createdAt.toISOString().replace('T', ' ').substring(0, 19)
 
@@ -146,6 +149,7 @@ export async function GET(request: Request, context: RouteContext) {
         attendeeFirstName,
         attendeeLastName,
         attendeeEmail,
+        organization,
         phoneNumber: '',
         purchaserCity: ticket.order.buyerCity || '',
         purchaserState: '',

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -922,11 +922,12 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="buyer-organization">Organization</Label>
+              <Label htmlFor="buyer-organization" required>Organization</Label>
               <Input
                 id="buyer-organization"
                 value={buyer.organization}
                 onChange={(eventValue) => updateBuyerField('organization', eventValue.target.value)}
+                required
               />
             </div>
             <div className="space-y-2 sm:col-span-2">
@@ -1092,7 +1093,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                               />
                             </div>
                             <div className="space-y-1">
-                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-organization`}>
+                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-organization`} required>
                                 Organization
                               </Label>
                               <Input
@@ -1103,6 +1104,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                     ? updateBuyerField('organization', e.target.value)
                                     : updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
                                 }
+                                required
                               />
                             </div>
                             {event.collectAllergies && (

--- a/src/lib/validations/order.ts
+++ b/src/lib/validations/order.ts
@@ -5,7 +5,7 @@ export const buyerInfoSchema = z.object({
   lastName: z.string().min(1, 'Last name is required'),
   title: z.string().optional(),
   email: z.string().email('Invalid email address'),
-  organization: z.string().optional(),
+  organization: z.string().min(1, 'Organization is required'),
   address: z.string().optional(),
   city: z.string().optional(),
   postalCode: z.string().optional(),
@@ -17,7 +17,7 @@ export const checkoutAttendeeSchema = z.object({
   lastName: z.string().min(1, 'Last name is required'),
   email: z.string().email('Invalid email address'),
   title: z.string().optional(),
-  organization: z.string().optional(),
+  organization: z.string().min(1, 'Organization is required'),
 })
 
 export const orderItemSchema = z.object({


### PR DESCRIPTION
## Summary
- Make the organization field required for both buyer and attendee during checkout (validation + form UI)
- Add organization column to Excel attendee export (CSV already included it)
- Remove debug APP_URL banner from the admin dashboard

## Test plan
- [x] Verify checkout form shows organization as required for buyer and each attendee
- [x] Submit checkout without organization and confirm validation error appears
- [x] Export attendees as Excel and verify the Organization column is present with correct data
- [x] Export attendees as CSV and verify organization still works as before
- [x] Confirm the debug yellow banner is no longer visible on the dashboard