### PR TITLE
fix(checkout): make buyer-to-first-attendee pre-fill one-way

### DIFF
--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
@@ -481,11 +481,28 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
     })
   }, [selectedItems])
 
-  // Keep first attendee in the first selected ticket type synced 1:1 with buyer details.
+  // One-way pre-fill: buyer -> first attendee of the first selected ticket type.
+  // Only overwrite fields the user hasn't edited (i.e., still equal to the last synced buyer value).
+  const lastSyncedBuyerRef = useRef({
+    firstName: '',
+    lastName: '',
+    email: '',
+    title: '',
+    organization: '',
+  })
   useEffect(() => {
     if (selectedItems.length === 0) return
 
     const firstTypeId = selectedItems[0].ticketTypeId
+    const prev = lastSyncedBuyerRef.current
+    const nextBuyerSnapshot = {
+      firstName: buyer.firstName,
+      lastName: buyer.lastName,
+      email: buyer.email,
+      title: buyer.title,
+      organization: buyer.organization,
+    }
+    lastSyncedBuyerRef.current = nextBuyerSnapshot
 
     setAttendeesByType((current) => {
       const slots = current[firstTypeId]
@@ -494,11 +511,11 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
       const first = slots[0]
       const nextFirst: AttendeeFormState = {
         ...first,
-        firstName: buyer.firstName,
-        lastName: buyer.lastName,
-        email: buyer.email,
-        title: buyer.title,
-        organization: buyer.organization,
+        firstName: first.firstName === prev.firstName ? buyer.firstName : first.firstName,
+        lastName: first.lastName === prev.lastName ? buyer.lastName : first.lastName,
+        email: first.email === prev.email ? buyer.email : first.email,
+        title: first.title === prev.title ? buyer.title : first.title,
+        organization: first.organization === prev.organization ? buyer.organization : first.organization,
       }
 
       const unchanged =
@@ -512,10 +529,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
 
       return {
         ...current,
-        [firstTypeId]: [
-          nextFirst,
-          ...slots.slice(1),
-        ],
+        [firstTypeId]: [nextFirst, ...slots.slice(1)],
       }
     })
   }, [selectedItems, buyer.firstName, buyer.lastName, buyer.email, buyer.title, buyer.organization])
@@ -658,7 +672,6 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
     }
 
     const buyerEmailValue = buyer.email.trim()
-    const firstSelectedTicketTypeId = selectedItems[0]?.ticketTypeId
 
     if (!buyer.firstName || !buyer.lastName) {
       setSubmitError('First name and last name are required')
@@ -680,18 +693,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
     for (const item of selectedItems) {
       const slots = attendeesByType[item.ticketTypeId] ?? []
       for (let i = 0; i < item.quantity; i++) {
-        const linkedToBuyer = item.ticketTypeId === firstSelectedTicketTypeId && i === 0
-        const a = linkedToBuyer
-          ? {
-              ...(slots[i] ?? emptyAttendee()),
-              firstName: buyer.firstName,
-              lastName: buyer.lastName,
-              email: buyerEmailValue,
-              title: buyer.title,
-              organization: buyer.organization,
-            }
-          : slots[i]
-
+        const a = slots[i]
         if (!a || !a.firstName || !a.lastName || !a.email) {
           const ticketName = displayTicketTypes.find((t) => t.id === item.ticketTypeId)?.name ?? 'ticket'
           setSubmitError(`Please fill in all attendee details for "${ticketName}" (ticket ${i + 1})`)
@@ -718,21 +720,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
           items: selectedItems.map((item) => ({
             ticketTypeId: item.ticketTypeId,
             quantity: item.quantity,
-            attendees: (attendeesByType[item.ticketTypeId] ?? [])
-              .slice(0, item.quantity)
-              .map((attendee, index) => {
-                const linkedToBuyer = item.ticketTypeId === firstSelectedTicketTypeId && index === 0
-                if (!linkedToBuyer) return attendee
-
-                return {
-                  ...(attendee ?? emptyAttendee()),
-                  firstName: buyer.firstName,
-                  lastName: buyer.lastName,
-                  email: buyerEmailValue,
-                  title: buyer.title,
-                  organization: buyer.organization,
-                }
-              }),
+            attendees: (attendeesByType[item.ticketTypeId] ?? []).slice(0, item.quantity),
           })),
           buyer: {
             ...buyer,
@@ -989,17 +977,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                   <div key={item.ticketTypeId} className="space-y-4">
                     {Array.from({ length: item.quantity }, (_, i) => {
                       const attendee = slots[i] ?? emptyAttendee()
-                      const isBuyerLinkedAttendee = item.ticketTypeId === selectedItems[0]?.ticketTypeId && i === 0
-                      const attendeeDisplay = isBuyerLinkedAttendee
-                        ? {
-                            ...attendee,
-                            firstName: buyer.firstName,
-                            lastName: buyer.lastName,
-                            email: buyer.email,
-                            title: buyer.title,
-                            organization: buyer.organization,
-                          }
-                        : attendee
+                      const attendeeDisplay = attendee
                       const label =
                         item.quantity > 1
                           ? `${ticketType?.name ?? 'Ticket'} #${i + 1}`
@@ -1012,7 +990,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                         >
                           <div className="mb-3 flex items-center justify-between gap-2">
                             <p className="text-sm font-medium text-gray-700">{label}</p>
-                            {!isBuyerLinkedAttendee && buyer.firstName && buyer.lastName && buyer.email && (
+                            {buyer.firstName && buyer.lastName && buyer.email && (
                               <button
                                 type="button"
                                 onClick={() => fillAttendeeFromBuyer(item.ticketTypeId, i)}
@@ -1034,9 +1012,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 id={`attendee-${item.ticketTypeId}-${i}-first-name`}
                                 value={attendeeDisplay.firstName}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('firstName', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
                                 }
                                 required
                               />
@@ -1052,9 +1028,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 id={`attendee-${item.ticketTypeId}-${i}-last-name`}
                                 value={attendeeDisplay.lastName}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('lastName', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
                                 }
                                 required
                               />
@@ -1071,9 +1045,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 type="email"
                                 value={attendeeDisplay.email}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('email', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
                                 }
                                 required
                               />
@@ -1086,9 +1058,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 id={`attendee-${item.ticketTypeId}-${i}-title`}
                                 value={attendeeDisplay.title}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('title', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'title', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'title', e.target.value)
                                 }
                               />
                             </div>
@@ -1100,9 +1070,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 id={`attendee-${item.ticketTypeId}-${i}-organization`}
                                 value={attendeeDisplay.organization}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('organization', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
                                 }
                                 required
                               />


### PR DESCRIPTION
## Summary
- Editing the pre-filled first attendee no longer mutates the buyer form. The buyer→first-attendee link is now one-way.
- Buyer values still pre-fill the first ticket's attendee fields, but only for fields the user hasn't edited (tracked via a `lastSyncedBuyerRef`).
- The "Fill from my details" button is now also available on the first ticket.

## Test plan
- [x] Select tickets, fill buyer info — first ticket attendee fields auto-fill.
- [x] Edit a field on the first ticket attendee — buyer form is unchanged.
- [x] Continue editing the buyer form — only the unedited first-attendee fields stay in sync; user-edited ones are preserved.
- [x] "Fill from my details" appears on every ticket (including the first) and overwrites that attendee's fields with the current buyer values.
- [x] Submit order — attendee data is whatever was in the form (not silently overwritten with buyer info).