### PR TITLE
fix(checkout): clear VAT breakdown, TIER_PRICE group discount, manual-order VAT

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -403,8 +403,16 @@ model GroupDiscount {
   eventId         String
   ticketTypeId    String?     // null = all ticket types
   minQuantity     Int         // Buy X tickets
-  discountType    String      @default("PERCENTAGE") // PERCENTAGE or FIXED
-  discountValue   Decimal     @db.Decimal(10, 2)     // Get Y% or $Y off
+  discountType    String      @default("PERCENTAGE") // PERCENTAGE, FIXED, or TIER_PRICE
+  // Interpretation depends on discountType:
+  //   PERCENTAGE -> percent off (e.g. 20 = 20%)
+  //   FIXED      -> absolute amount off (VAT-inclusive)
+  //   TIER_PRICE -> per-ticket target price in the same ex-VAT convention as
+  //                TicketType.price (e.g. 6100 means each ticket is priced
+  //                at 6100 SEK ex-VAT when minQuantity is reached). Avoids
+  //                the rounding drift that PERCENTAGE introduces when the
+  //                organizer's rate card uses fixed tier prices.
+  discountValue   Decimal     @db.Decimal(10, 2)
   isActive        Boolean     @default(true)
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt

--- a/src/app/(dashboard)/dashboard/events/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/edit/page.tsx
@@ -110,7 +110,7 @@ export default async function EditEventPage({ params }: PageProps) {
           id: gd.id,
           ticketTypeId: gd.ticketTypeId ?? '',
           minQuantity: String(gd.minQuantity),
-          discountType: gd.discountType as 'PERCENTAGE' | 'FIXED',
+          discountType: gd.discountType as 'PERCENTAGE' | 'FIXED' | 'TIER_PRICE',
           discountValue: String(Number(gd.discountValue)),
           isActive: gd.isActive,
         }))}

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/tickets'
 import { generateOrderNumber } from '@/lib/utils'
 import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
+import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 import { z } from 'zod'
 
 type DiscountCodeWithLinks = Prisma.DiscountCodeGetPayload<{
@@ -32,29 +33,37 @@ type GroupDiscountRecord = {
 
 function calculateGroupDiscountAmount(
   groupDiscount: GroupDiscountRecord,
-  items: { ticketTypeId: string; quantity: number; totalPrice: number }[]
+  items: { ticketTypeId: string; quantity: number; unitPrice: number; totalPrice: number }[],
+  vatRate: number
 ): number {
   const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
   const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0)
+  const value = decimalToNumber(groupDiscount.discountValue)
+  const targetUnitInclVat = value * (1 + (vatRate ?? 0))
 
   if (groupDiscount.ticketTypeId === null) {
-    // Global discount - check total quantity
     if (totalQuantity < groupDiscount.minQuantity) return 0
 
-    const value = decimalToNumber(groupDiscount.discountValue)
     if (groupDiscount.discountType === 'PERCENTAGE') {
       return Number(Math.min(subtotal, (subtotal * value) / 100).toFixed(2))
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced = items.reduce(
+        (sum, item) => sum + Math.max(0, item.unitPrice - targetUnitInclVat) * item.quantity,
+        0
+      )
+      return Number(Math.min(subtotal, reduced).toFixed(2))
     } else {
       return Number(Math.min(subtotal, value).toFixed(2))
     }
   } else {
-    // Ticket-specific discount
     const applicableItem = items.find(item => item.ticketTypeId === groupDiscount.ticketTypeId)
     if (!applicableItem || applicableItem.quantity < groupDiscount.minQuantity) return 0
 
-    const value = decimalToNumber(groupDiscount.discountValue)
     if (groupDiscount.discountType === 'PERCENTAGE') {
       return Number(Math.min(applicableItem.totalPrice, (applicableItem.totalPrice * value) / 100).toFixed(2))
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced = Math.max(0, applicableItem.unitPrice - targetUnitInclVat) * applicableItem.quantity
+      return Number(Math.min(applicableItem.totalPrice, reduced).toFixed(2))
     } else {
       return Number(Math.min(applicableItem.totalPrice, value).toFixed(2))
     }
@@ -280,7 +289,7 @@ export async function POST(request: NextRequest) {
 
           if (gd && gd.eventId === input.eventId && gd.isActive) {
             groupDiscountRecord = gd
-            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items)
+            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items, vatRate)
           }
         }
 
@@ -313,6 +322,7 @@ export async function POST(request: NextRequest) {
         }
 
         const totalAmount = Number(Math.max(0, subtotal - discountAmount).toFixed(2))
+        const vatAmount = getIncludedVatFromVatInclusiveTotal(totalAmount, vatRate)
 
         const order = await tx.order.create({
           data: {
@@ -333,6 +343,8 @@ export async function POST(request: NextRequest) {
             subtotal,
             discountAmount,
             totalAmount,
+            vatRate,
+            vatAmount,
             currency: ticketTypes[0]?.currency ?? 'SEK',
             status: 'PENDING_INVOICE',
             paymentMethod: 'INVOICE',
@@ -428,6 +440,8 @@ export async function POST(request: NextRequest) {
           quantity: item.quantity,
           price: `${item.totalPrice.toString()} ${createdOrder.currency}`,
         })),
+        vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
+        vatAmount: createdOrder.vatAmount ? createdOrder.vatAmount.toString() : null,
       })
     }
 

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -38,19 +38,29 @@ type GroupDiscountRecord = {
 
 function calculateGroupDiscountAmount(
   groupDiscount: GroupDiscountRecord,
-  items: { ticketTypeId: string; quantity: number; totalPrice: number }[]
+  items: { ticketTypeId: string; quantity: number; unitPrice: number; totalPrice: number }[],
+  vatRate: number
 ): number {
   const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
   const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0)
+  const value = decimalToNumber(groupDiscount.discountValue)
+  // TIER_PRICE: organizer enters the exact per-ticket price (ex-VAT, matching
+  // ticketType.price convention) that applies when minQuantity is reached.
+  // Convert to VAT-inclusive so it matches the stored item.unitPrice.
+  const targetUnitInclVat = value * (1 + (vatRate ?? 0))
 
-  // Check if discount applies
   if (groupDiscount.ticketTypeId === null) {
     // Global discount - check total quantity
     if (totalQuantity < groupDiscount.minQuantity) return 0
 
-    const value = decimalToNumber(groupDiscount.discountValue)
     if (groupDiscount.discountType === 'PERCENTAGE') {
       return Number(Math.min(subtotal, (subtotal * value) / 100).toFixed(2))
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced = items.reduce(
+        (sum, item) => sum + Math.max(0, item.unitPrice - targetUnitInclVat) * item.quantity,
+        0
+      )
+      return Number(Math.min(subtotal, reduced).toFixed(2))
     } else {
       return Number(Math.min(subtotal, value).toFixed(2))
     }
@@ -59,9 +69,11 @@ function calculateGroupDiscountAmount(
     const applicableItem = items.find(item => item.ticketTypeId === groupDiscount.ticketTypeId)
     if (!applicableItem || applicableItem.quantity < groupDiscount.minQuantity) return 0
 
-    const value = decimalToNumber(groupDiscount.discountValue)
     if (groupDiscount.discountType === 'PERCENTAGE') {
       return Number(Math.min(applicableItem.totalPrice, (applicableItem.totalPrice * value) / 100).toFixed(2))
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced = Math.max(0, applicableItem.unitPrice - targetUnitInclVat) * applicableItem.quantity
+      return Number(Math.min(applicableItem.totalPrice, reduced).toFixed(2))
     } else {
       return Number(Math.min(applicableItem.totalPrice, value).toFixed(2))
     }
@@ -357,7 +369,7 @@ export async function POST(request: NextRequest) {
 
           if (gd && gd.eventId === input.eventId && gd.isActive) {
             groupDiscountRecord = gd
-            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items)
+            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items, vatRate)
           }
         }
 

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -62,7 +62,7 @@ type GroupDiscountDraft = {
   id?: string;
   ticketTypeId: string;
   minQuantity: string;
-  discountType: "PERCENTAGE" | "FIXED";
+  discountType: "PERCENTAGE" | "FIXED" | "TIER_PRICE";
   discountValue: string;
   isActive: boolean;
 };
@@ -4961,12 +4961,13 @@ export function EventForm({
                             updateGroupDiscountField(
                               index,
                               "discountType",
-                              e.target.value as "PERCENTAGE" | "FIXED",
+                              e.target.value as "PERCENTAGE" | "FIXED" | "TIER_PRICE",
                             )
                           }
                         >
                           <option value="PERCENTAGE">Percentage</option>
                           <option value="FIXED">Fixed Amount</option>
+                          <option value="TIER_PRICE">Fixed per-ticket price (ex. VAT)</option>
                         </select>
                         <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-500" />
                       </div>
@@ -4978,7 +4979,9 @@ export function EventForm({
                       >
                         {gd.discountType === "PERCENTAGE"
                           ? "Discount %"
-                          : "Discount Amount"}
+                          : gd.discountType === "TIER_PRICE"
+                            ? "Per-ticket price (ex. VAT)"
+                            : "Discount Amount"}
                       </label>
                       <input
                         id={`gdDiscountValue-${index}`}
@@ -4986,7 +4989,11 @@ export function EventForm({
                         inputMode="decimal"
                         value={gd.discountValue}
                         placeholder={
-                          gd.discountType === "PERCENTAGE" ? "e.g., 10" : "e.g., 5.00"
+                          gd.discountType === "PERCENTAGE"
+                            ? "e.g., 10"
+                            : gd.discountType === "TIER_PRICE"
+                              ? "e.g., 6100"
+                              : "e.g., 5.00"
                         }
                         className="h-[42px] w-full rounded-[10px] border border-[#d1d5dc] bg-white px-4 text-base outline-none focus:border-[#5c8bd9] focus:ring-1 focus:ring-[#5c8bd9]"
                         onChange={(e) => {

--- a/src/components/events/GroupDiscountEditor.tsx
+++ b/src/components/events/GroupDiscountEditor.tsx
@@ -16,7 +16,7 @@ interface GroupDiscount {
   ticketTypeId: string | null
   ticketTypeName: string
   minQuantity: number
-  discountType: 'PERCENTAGE' | 'FIXED'
+  discountType: 'PERCENTAGE' | 'FIXED' | 'TIER_PRICE'
   discountValue: number
   isActive: boolean
 }
@@ -36,7 +36,7 @@ export function GroupDiscountEditor({ eventId, ticketTypes }: GroupDiscountEdito
   const [newDiscount, setNewDiscount] = useState({
     ticketTypeId: '',
     minQuantity: 2,
-    discountType: 'PERCENTAGE' as 'PERCENTAGE' | 'FIXED',
+    discountType: 'PERCENTAGE' as 'PERCENTAGE' | 'FIXED' | 'TIER_PRICE',
     discountValue: 10,
     isActive: true,
   })
@@ -270,12 +270,13 @@ export function GroupDiscountEditor({ eventId, ticketTypes }: GroupDiscountEdito
                 onChange={(e) =>
                   setNewDiscount({
                     ...newDiscount,
-                    discountType: e.target.value as 'PERCENTAGE' | 'FIXED',
+                    discountType: e.target.value as 'PERCENTAGE' | 'FIXED' | 'TIER_PRICE',
                   })
                 }
               >
                 <option value="PERCENTAGE">Percentage</option>
                 <option value="FIXED">Fixed Amount</option>
+                <option value="TIER_PRICE">Fixed per-ticket price (ex. VAT)</option>
               </select>
             </div>
 
@@ -298,7 +299,11 @@ export function GroupDiscountEditor({ eventId, ticketTypes }: GroupDiscountEdito
                 required
               />
               <p className="text-xs text-gray-500">
-                {newDiscount.discountType === 'PERCENTAGE' ? 'Percentage (e.g., 10 for 10%)' : 'Fixed amount'}
+                {newDiscount.discountType === 'PERCENTAGE'
+                  ? 'Percentage (e.g., 10 for 10%)'
+                  : newDiscount.discountType === 'TIER_PRICE'
+                    ? 'Per-ticket price ex. VAT when minimum quantity is met (e.g., 6100 = 6 100 per ticket)'
+                    : 'Fixed amount (VAT-inclusive)'}
               </p>
             </div>
           </div>
@@ -376,7 +381,7 @@ export function GroupDiscountEditor({ eventId, ticketTypes }: GroupDiscountEdito
                             onChange={(e) =>
                               setEditForm({
                                 ...editForm,
-                                discountType: e.target.value as 'PERCENTAGE' | 'FIXED',
+                                discountType: e.target.value as 'PERCENTAGE' | 'FIXED' | 'TIER_PRICE',
                               })
                             }
                           >
@@ -418,11 +423,12 @@ export function GroupDiscountEditor({ eventId, ticketTypes }: GroupDiscountEdito
                           {discount.ticketTypeName}
                         </p>
                         <p className="text-sm text-gray-600">
-                          Buy {discount.minQuantity}+ tickets, get{' '}
+                          Buy {discount.minQuantity}+ tickets,{' '}
                           {discount.discountType === 'PERCENTAGE'
-                            ? `${discount.discountValue}%`
-                            : `$${discount.discountValue}`}{' '}
-                          off
+                            ? `get ${discount.discountValue}% off`
+                            : discount.discountType === 'TIER_PRICE'
+                              ? `pay ${discount.discountValue} per ticket (ex. VAT)`
+                              : `get ${discount.discountValue} off`}
                         </p>
                         <p className="text-xs text-gray-500">
                           Status: {discount.isActive ? 'Active' : 'Inactive'}

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -80,7 +80,7 @@ function formatTierOffer(
 ): string {
   if (discount.discountType === 'PERCENTAGE') return `get ${discount.discountValue}% off!`
   if (discount.discountType === 'TIER_PRICE') {
-    return `pay ${discount.discountValue} ${currency} per ticket!`
+    return `pay ${discount.discountValue} ${currency} per ticket (excl. VAT)!`
   }
   return `get ${discount.discountValue} ${currency} off!`
 }

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -74,9 +74,21 @@ function emptyAttendee(): AttendeeFormState {
   return { firstName: '', lastName: '', email: '', title: '', organization: '', allergies: '' }
 }
 
+function formatTierOffer(
+  discount: GroupDiscount,
+  currency: string
+): string {
+  if (discount.discountType === 'PERCENTAGE') return `get ${discount.discountValue}% off!`
+  if (discount.discountType === 'TIER_PRICE') {
+    return `pay ${discount.discountValue} ${currency} per ticket!`
+  }
+  return `get ${discount.discountValue} ${currency} off!`
+}
+
 function calculateBestGroupDiscount(
   selectedItems: SummaryLineItem[],
-  groupDiscounts: GroupDiscount[]
+  groupDiscounts: GroupDiscount[],
+  vatRate: number
 ): { amount: number; description: string | null; id: string | null } {
   if (!groupDiscounts || groupDiscounts.length === 0) {
     return { amount: 0, description: null, id: null }
@@ -86,10 +98,9 @@ function calculateBestGroupDiscount(
   let bestDescription: string | null = null
   let bestId: string | null = null
 
-  // Calculate total quantity across all ticket types
   const totalQuantity = selectedItems.reduce((sum, item) => sum + item.quantity, 0)
+  const vatMultiplier = 1 + (vatRate ?? 0)
 
-  // Check discounts that apply to all ticket types (ticketTypeId = null)
   const globalDiscounts = groupDiscounts
     .filter((gd) => gd.ticketTypeId === null && totalQuantity >= gd.minQuantity)
     .sort((a, b) => b.minQuantity - a.minQuantity)
@@ -101,6 +112,14 @@ function calculateBestGroupDiscount(
     let discountAmount = 0
     if (topGlobalDiscount.discountType === 'PERCENTAGE') {
       discountAmount = (subtotal * topGlobalDiscount.discountValue) / 100
+    } else if (topGlobalDiscount.discountType === 'TIER_PRICE') {
+      // discountValue is the per-ticket target price in the ex-VAT convention
+      // (matching ticketType.price). Convert to VAT-inclusive for comparison.
+      const targetInclVat = topGlobalDiscount.discountValue * vatMultiplier
+      discountAmount = selectedItems.reduce(
+        (sum, item) => sum + Math.max(0, item.unitPrice - targetInclVat) * item.quantity,
+        0
+      )
     } else if (topGlobalDiscount.discountType === 'FIXED') {
       discountAmount = topGlobalDiscount.discountValue
     }
@@ -108,15 +127,11 @@ function calculateBestGroupDiscount(
     if (discountAmount > bestDiscount) {
       bestDiscount = discountAmount
       bestId = topGlobalDiscount.id
-      bestDescription = `Buy ${topGlobalDiscount.minQuantity}+ tickets, get ${
-        topGlobalDiscount.discountType === 'PERCENTAGE'
-          ? `${topGlobalDiscount.discountValue}%`
-          : `$${topGlobalDiscount.discountValue}`
-      } off!`
+      const currency = selectedItems[0]?.currency ?? ''
+      bestDescription = `Buy ${topGlobalDiscount.minQuantity}+ tickets, ${formatTierOffer(topGlobalDiscount, currency)}`
     }
   }
 
-  // Check discounts specific to ticket types
   for (const item of selectedItems) {
     const ticketDiscounts = groupDiscounts
       .filter((gd) => gd.ticketTypeId === item.ticketTypeId && item.quantity >= gd.minQuantity)
@@ -128,6 +143,9 @@ function calculateBestGroupDiscount(
       let discountAmount = 0
       if (topTicketDiscount.discountType === 'PERCENTAGE') {
         discountAmount = (item.totalPrice * topTicketDiscount.discountValue) / 100
+      } else if (topTicketDiscount.discountType === 'TIER_PRICE') {
+        const targetInclVat = topTicketDiscount.discountValue * vatMultiplier
+        discountAmount = Math.max(0, item.unitPrice - targetInclVat) * item.quantity
       } else if (topTicketDiscount.discountType === 'FIXED') {
         discountAmount = topTicketDiscount.discountValue
       }
@@ -135,11 +153,7 @@ function calculateBestGroupDiscount(
       if (discountAmount > bestDiscount) {
         bestDiscount = discountAmount
         bestId = topTicketDiscount.id
-        bestDescription = `Buy ${topTicketDiscount.minQuantity}+ ${item.name} tickets, get ${
-          topTicketDiscount.discountType === 'PERCENTAGE'
-            ? `${topTicketDiscount.discountValue}%`
-            : `$${topTicketDiscount.discountValue}`
-        } off!`
+        bestDescription = `Buy ${topTicketDiscount.minQuantity}+ ${item.name} tickets, ${formatTierOffer(topTicketDiscount, item.currency)}`
       }
     }
   }
@@ -405,8 +419,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
   )
 
   const groupDiscount = useMemo(
-    () => calculateBestGroupDiscount(selectedItems, groupDiscounts),
-    [selectedItems, groupDiscounts]
+    () => calculateBestGroupDiscount(selectedItems, groupDiscounts, vatRate),
+    [selectedItems, groupDiscounts, vatRate]
   )
 
   const promoCodeDiscountAmount = useMemo(

--- a/src/components/tickets/OrderSummary.tsx
+++ b/src/components/tickets/OrderSummary.tsx
@@ -25,6 +25,18 @@ interface OrderSummaryProps {
   freeOrderMessage?: string | null
 }
 
+// Stored `subtotal`, `discountAmount`, and `totalAmount` are VAT-inclusive
+// (see src/lib/orders/index.ts). To avoid the confusion of showing "Total"
+// above "VAT (25%)" where 25% of the total does not equal the VAT line
+// (bug: kvitto-visar-fel-baspris rapport 2026-04-14), the summary presents
+// the VAT-exclusive base, the discount, the VAT, and the VAT-inclusive total
+// on separate rows so that subtotalExVat - discountExVat + vat = total.
+function toExVat(amountInclVat: number, vatRate: number): number {
+  if (vatRate <= 0) return Number(amountInclVat.toFixed(2))
+  const multiplier = 1 + vatRate
+  return Number((amountInclVat / multiplier).toFixed(2))
+}
+
 export function OrderSummary({
   items,
   subtotal,
@@ -37,6 +49,9 @@ export function OrderSummary({
   groupDiscountMessage,
   freeOrderMessage,
 }: OrderSummaryProps) {
+  const hasVat = vatRate > 0
+  const subtotalExVat = toExVat(subtotal, vatRate)
+  const discountExVat = toExVat(discountAmount, vatRate)
   return (
     <Card>
       <CardHeader>
@@ -65,8 +80,8 @@ export function OrderSummary({
 
         <div className="space-y-2 border-t border-gray-200 pt-3 text-sm">
           <div className="flex items-center justify-between text-gray-600">
-            <span>Subtotal</span>
-            <span>{formatCurrency(subtotal, currency)}</span>
+            <span>{hasVat ? 'Subtotal (excl. VAT)' : 'Subtotal'}</span>
+            <span>{formatCurrency(subtotalExVat, currency)}</span>
           </div>
 
           {freeOrderMessage && (
@@ -85,7 +100,7 @@ export function OrderSummary({
                       ? 'Group Discount'
                       : 'Discount'}
                 </span>
-                <span>-{formatCurrency(discountAmount, currency)}</span>
+                <span>-{formatCurrency(discountExVat, currency)}</span>
               </div>
               {groupDiscountMessage && (
                 <p className="text-xs text-green-600">{groupDiscountMessage}</p>
@@ -105,13 +120,16 @@ export function OrderSummary({
             </div>
           )}
 
+          {hasVat && (
+            <div className="flex items-center justify-between text-gray-600">
+              <span>VAT ({Math.round(vatRate * 100)}%)</span>
+              <span>{formatCurrency(includedVat, currency)}</span>
+            </div>
+          )}
+
           <div className="flex items-center justify-between border-t border-gray-200 pt-2 font-semibold text-gray-900">
-            <span>Total</span>
+            <span>{hasVat ? 'Total (incl. VAT)' : 'Total'}</span>
             <span>{formatCurrency(totalAmount, currency)}</span>
-          </div>
-          <div className="flex items-center justify-between text-gray-600">
-            <span>VAT ({Math.round(vatRate * 100)}%)</span>
-            <span>{formatCurrency(includedVat, currency)}</span>
           </div>
         </div>
       </CardContent>

--- a/src/components/tickets/OrderSummary.tsx
+++ b/src/components/tickets/OrderSummary.tsx
@@ -105,18 +105,6 @@ export function OrderSummary({
               {groupDiscountMessage && (
                 <p className="text-xs text-green-600">{groupDiscountMessage}</p>
               )}
-              {groupDiscountMessage && subtotal > 0 && (
-                <div className="mt-1 space-y-0.5">
-                  {items.map((item) => {
-                    const discountedUnit = item.unitPrice * (1 - discountAmount / subtotal)
-                    return (
-                      <p key={item.ticketTypeId} className="text-xs text-green-600">
-                        {item.name}: {formatCurrency(discountedUnit, currency)} per ticket after discount
-                      </p>
-                    )
-                  })}
-                </div>
-              )}
             </div>
           )}
 

--- a/src/lib/validations/event.ts
+++ b/src/lib/validations/event.ts
@@ -93,7 +93,7 @@ export const eventMediaSchema = z.object({
 const groupDiscountBaseSchema = z.object({
   ticketTypeId: z.string().cuid().optional().nullable(),
   minQuantity: z.number().min(1, 'Minimum quantity must be at least 1'),
-  discountType: z.enum(['PERCENTAGE', 'FIXED']).default('PERCENTAGE'),
+  discountType: z.enum(['PERCENTAGE', 'FIXED', 'TIER_PRICE']).default('PERCENTAGE'),
   discountValue: z.number().min(0, 'Discount value must be positive').refine((val) => val > 0, {
     message: 'Discount value must be greater than 0',
   }),


### PR DESCRIPTION
## Summary

Addresses the STSWE26 checkout bug report (2026-04-14) covering the `OE-MNYYNG870-N5VG` order where the receipt and order summary presented VAT in a way that was inconsistent with both the customer's expectation and the invoice sent alongside it.

- **Order Summary reordered and relabeled** (bug 3). The layout now shows `Subtotal (excl. VAT)`, `Discount`, `VAT (25%)`, `Total (incl. VAT)` in sequence so the numbers visibly reconcile. The previous layout placed `Total` above `VAT (25%)` where the VAT row showed *included* VAT (25% of the ex-VAT base, not 25% of the total), making it look like the VAT didn't match the total.

- **New `TIER_PRICE` group-discount type** (bug 2). `discountValue` becomes the exact per-ticket price in the same ex-VAT convention as `TicketType.price`. A rate card with fixed tier prices (e.g. 6 100 SEK/ticket at 3+) no longer has to be expressed as a percentage that rounds to 6 099,75 SEK. The type is plumbed through the zod validator, the Prisma schema comments, both order-creation APIs, and the admin discount editors (`EventForm` and `GroupDiscountEditor`).

- **Manual orders now persist `vatRate` and `vatAmount`** on the order row and include them in the organizer notification email (bug 4). Previously these fields were missing on manual orders, so downstream invoice generation had no VAT reference and would treat `totalAmount` as ex-VAT and add 25% on top — the exact cause of the 18 299,25 vs 22 874,06 mismatch in the report.

### Notes on bug 1

Bug 1 (receipt unit price showing 6 000 instead of 7 500) is rooted in the data entered for this event: the stored `ticketType.price` for the order in question produces 7 500 SEK VAT-inclusive / 6 000 SEK ex-VAT, rather than the 7 500 SEK ex-VAT value listed on streamingtech.se. The receipt's ex-VAT computation is correct for the stored data; the fix is for the organizer to re-enter the tier prices using the new `TIER_PRICE` group discount so the rate-card values (7 500 / 6 100 / 5 200 / 4 600 SEK ex-VAT) go straight into the system without percentage rounding.

## Test plan

- [x] `npx vitest run` — 80/80 tests pass
- [x] `npx tsc --noEmit` clean (no new type errors)
- [x] Manual: place a 3-ticket order and verify the Order Summary shows Subtotal (ex-VAT) − Discount + VAT = Total (incl-VAT)
- [x] Manual: create a `TIER_PRICE` group discount in the dashboard, place a qualifying order, and verify per-ticket price matches the configured tier (no rounding drift)
- [x] Manual: create a manual invoice order and verify the organizer notification email shows the `VAT (25%)` line with the correct amount