### PR TITLE
chore/fix: remove APP_URL debug banner, show event 'From' price excl. VAT

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -88,17 +88,8 @@ export default async function DashboardHomePage() {
 
   const welcomeName = organizerProfile?.orgName || user.name || 'Admin'
 
-  const resolvedAppUrl = process.env.PUBLIC_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-
   return (
     <div className="space-y-6">
-      {/* DEBUG: remove after verifying payment redirect URLs */}
-      <div className="rounded bg-yellow-100 border border-yellow-400 px-4 py-2 text-sm text-yellow-800">
-        <strong>DEBUG</strong> — Resolved APP_URL: <code>{resolvedAppUrl}</code>
-        <span className="ml-2 text-xs text-yellow-600">
-          (PUBLIC_URL={process.env.PUBLIC_URL ?? 'unset'}, NEXT_PUBLIC_APP_URL={process.env.NEXT_PUBLIC_APP_URL ?? 'unset'})
-        </span>
-      </div>
       <WorkspacePageHeader
         title={`Welcome, ${welcomeName}`}
         description="Platform-wide overview of events, orders, and revenue."

--- a/src/app/(public)/events/[slug]/page.tsx
+++ b/src/app/(public)/events/[slug]/page.tsx
@@ -6,7 +6,6 @@ import { prisma } from '@/lib/db'
 import { EventNoticeToast } from '@/components/events/EventNoticeToast'
 import { CHECKOUT_UNAVAILABLE_NOTICE } from '@/lib/orders/checkoutAvailability'
 import { isValidTimeZone } from '@/lib/timezone'
-import { getPriceIncludingVat } from '@/lib/pricing/vat'
 import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
 import { formatEventPrice, formatEventDateTime } from '@/lib/utils'
 import { sanitizeHtml } from '@/lib/sanitize'
@@ -80,11 +79,7 @@ export default async function EventDetailsPage({ params, searchParams }: PagePro
   const mapEmbedUrl = `https://www.google.com/maps?q=${mapQuery}&output=embed`
 
   const eventVatRate = getVatRateForCountryNameOrCode(event.country ?? '')
-  const ticketTypesWithVat = event.ticketTypes.map((ticketType) => ({
-    ...ticketType,
-    price: getPriceIncludingVat(Number(ticketType.price), eventVatRate),
-  }))
-  const priceDisplay = formatEventPrice(ticketTypesWithVat)
+  const priceDisplay = formatEventPrice(event.ticketTypes)
   const hasPaidTickets = event.ticketTypes.some((ticketType) => Number(ticketType.price) > 0)
   const bottomImage = event.media.find((item) => item.title === 'BOTTOM_IMAGE')?.url || null
   const coverImageSrc = `/api/events/${encodeURIComponent(event.slug)}/image?slot=cover&v=${event.updatedAt.getTime()}`
@@ -280,7 +275,7 @@ export default async function EventDetailsPage({ params, searchParams }: PagePro
                 className="mt-1 text-[13px] leading-5 text-[#4a5565]"
                 style={{ fontFamily: 'var(--font-outfit), sans-serif' }}
               >
-                VAT included ({Math.round(eventVatRate * 100)}%).
+                Excl. VAT ({Math.round(eventVatRate * 100)}%).
               </p>
             ) : null}
 


### PR DESCRIPTION
## Summary

Two small dashboard/public cleanups spotted while testing PR #310:

- **Remove the \`DEBUG — Resolved APP_URL: ...\` banner** on the organizer dashboard. It landed in #306 with a \`DEBUG: remove after verifying payment redirect URLs\` comment and was never pulled out. Payment redirects were verified in #305, so the banner is dead weight visible on every dashboard load.

- **Show the event 'From' price excluding VAT.** The event detail page applied \`getPriceIncludingVat\` to the rate card before running \`formatEventPrice\`, so a 7 500 SEK ex-VAT ticket rendered as \`From SEK 9,375 — VAT included (25%)\`. The rate card convention (and the admin \"Price excluding VAT\" field) is ex-VAT; show it ex-VAT on the event page and label it accordingly. VAT is still applied in the checkout/order summary.

## Test plan

- [x] Load the dashboard — no yellow debug banner at the top
- [x] Open a published event page with a 7 500 SEK ex-VAT General Admission ticket — the 'From' price reads \`SEK 7,500\` with \`Excl. VAT (25%).\` underneath (not \`9,375 — VAT included\`)