### PR TITLE
feat: send payment reminders for pending orders

### DIFF
--- a/prisma/migrations/20260416112626_add_order_reminder_sent_at/migration.sql
+++ b/prisma/migrations/20260416112626_add_order_reminder_sent_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN     "reminderSentAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -472,6 +472,7 @@ model Order {
   cancelledAt     DateTime?
   refundedAt      DateTime?
   invoiceSentAt   DateTime?    // When invoice was sent (for invoice orders)
+  reminderSentAt  DateTime?    // When a pending-payment reminder email was sent
 
   // Refund info
   refundStatus    RefundStatus?

--- a/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
@@ -3,7 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import { notFound, redirect } from 'next/navigation'
 import { Prisma, PaymentMethod } from '@prisma/client'
 import { prisma } from '@/lib/db'
-import { sendOrderConfirmationEmail } from '@/lib/email'
+import { sendOrderConfirmationEmail, sendPendingOrderReminderEmail } from '@/lib/email'
 import { requireOrganizerProfile, canAccessEvent } from '@/lib/dashboard/organizer'
 import { OrderDetailView } from '@/components/dashboard/OrderDetailView'
 import { generateTicketCreateInput, lockTicketTypes } from '@/lib/orders'
@@ -39,6 +39,7 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
       currency: true,
       createdAt: true,
       invoiceSentAt: true,
+      reminderSentAt: true,
       discountCode: {
         select: {
           code: true,
@@ -172,6 +173,64 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
     })
 
     revalidatePath(`/dashboard/events/${id}/orders/${submittedOrderId}`)
+  }
+
+  async function sendReminderAction(formData: FormData) {
+    'use server'
+
+    const { event: eventCheck } = await canAccessEvent(id)
+    if (!eventCheck) {
+      throw new Error('Event not found')
+    }
+
+    const submittedOrderId = String(formData.get('orderId') || '')
+
+    const targetOrder = await prisma.order.findFirst({
+      where: {
+        id: submittedOrderId,
+        eventId: id,
+        event: { id, deletedAt: null },
+      },
+      select: {
+        id: true,
+        status: true,
+        orderNumber: true,
+        buyerFirstName: true,
+        buyerLastName: true,
+        buyerEmail: true,
+        event: {
+          select: {
+            title: true,
+            slug: true,
+            startDate: true,
+          },
+        },
+      },
+    })
+
+    if (!targetOrder) {
+      throw new Error('Order not found')
+    }
+
+    if (targetOrder.status !== 'PENDING') {
+      throw new Error(`Only PENDING orders can be sent a payment reminder. Current status: ${targetOrder.status}`)
+    }
+
+    await sendPendingOrderReminderEmail(targetOrder.buyerEmail, {
+      buyerName: `${targetOrder.buyerFirstName} ${targetOrder.buyerLastName}`.trim(),
+      orderNumber: targetOrder.orderNumber,
+      eventTitle: targetOrder.event.title,
+      eventDate: formatDateTime(targetOrder.event.startDate),
+      eventSlug: targetOrder.event.slug,
+    })
+
+    await prisma.order.update({
+      where: { id: targetOrder.id },
+      data: { reminderSentAt: new Date() },
+    })
+
+    revalidatePath(`/dashboard/events/${id}/orders/${submittedOrderId}`)
+    revalidatePath(`/dashboard/events/${id}/orders`)
   }
 
   async function markPaidAction(formData: FormData) {
@@ -477,6 +536,7 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
         discountAmount: Number(order.discountAmount.toString()),
         totalAmount: Number(order.totalAmount.toString()),
         invoiceSentAt: order.invoiceSentAt,
+        reminderSentAt: order.reminderSentAt,
         discountCode: order.discountCode?.code ?? null,
         items: order.items.map((item) => ({
           ...item,
@@ -488,6 +548,7 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
       emailAction={emailAction}
       markPaidAction={markPaidAction}
       markInvoiceSentAction={markInvoiceSentAction}
+      sendReminderAction={sendReminderAction}
       deleteOrderAction={deleteOrderAction}
     />
     </div>

--- a/src/app/(dashboard)/dashboard/events/[id]/orders/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/orders/page.tsx
@@ -7,6 +7,8 @@ import { requireOrganizerProfile, buildEventWhereClause, canAccessEvent } from '
 import { OrderFilters } from '@/components/dashboard/OrderFilters'
 import { OrdersTable } from '@/components/dashboard/OrdersTable'
 import { BulkActionForm } from '@/components/dashboard/BulkActionForm'
+import { SendPendingRemindersButton } from '@/components/dashboard/SendPendingRemindersButton'
+import { sendPendingOrderReminders } from '@/lib/orders/sendPendingReminders'
 
 export const dynamic = 'force-dynamic'
 
@@ -96,6 +98,7 @@ export default async function EventOrdersPage({ params, searchParams }: PageProp
       totalAmount: true,
       currency: true,
       createdAt: true,
+      reminderSentAt: true,
       discountCode: {
         select: {
           code: true,
@@ -171,6 +174,19 @@ export default async function EventOrdersPage({ params, searchParams }: PageProp
     revalidatePath(`/dashboard/events/${id}/orders`)
   }
 
+  async function sendRemindersAction() {
+    'use server'
+
+    const { event: eventCheck } = await canAccessEvent(id)
+    if (!eventCheck) {
+      throw new Error('Event not found')
+    }
+
+    const result = await sendPendingOrderReminders({ eventId: id })
+    revalidatePath(`/dashboard/events/${id}/orders`)
+    return result
+  }
+
   const exportParams = new URLSearchParams()
   if (search) exportParams.set('search', search)
   if (status) exportParams.set('status', status)
@@ -229,7 +245,8 @@ export default async function EventOrdersPage({ params, searchParams }: PageProp
           <h1 className="text-3xl font-bold text-gray-900">Orders</h1>
           <p className="text-gray-600">Order management for {event.title}.</p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          <SendPendingRemindersButton action={sendRemindersAction} />
           <Link
             href={`/dashboard/events/${id}/orders/new`}
             className="inline-flex rounded-md bg-[#5C8BD9] px-4 py-2 text-sm font-medium text-white hover:bg-[#4a7ac8]"

--- a/src/app/(dashboard)/dashboard/events/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/page.tsx
@@ -46,6 +46,7 @@ export default async function EventDetailDashboardPage({ params }: PageProps) {
         currency: true,
         buyerEmail: true,
         createdAt: true,
+        reminderSentAt: true,
         event: { select: { id: true, title: true } },
       },
       orderBy: { createdAt: 'desc' },

--- a/src/app/(dashboard)/dashboard/orders/page.tsx
+++ b/src/app/(dashboard)/dashboard/orders/page.tsx
@@ -58,6 +58,7 @@ export default async function DashboardOrdersPage() {
       totalAmount: Number(order.totalAmount.toString()),
       currency: order.currency,
       buyerEmail: order.buyerEmail,
+      reminderSentAt: order.reminderSentAt ? order.reminderSentAt.toISOString() : null,
       event: {
         title: order.event.title,
         slug: order.event.slug,

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -64,6 +64,7 @@ export default async function DashboardHomePage() {
             currency: true,
             buyerEmail: true,
             createdAt: true,
+            reminderSentAt: true,
             event: { select: { id: true, title: true } },
           },
           orderBy: { createdAt: 'desc' },

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -10,7 +10,7 @@ import {
   getCheckoutUnavailableReason,
   getOrderErrorForCheckoutUnavailableReason,
 } from '@/lib/orders/checkoutAvailability'
-import { getOrderReservationExpiry, getOrderReservationTtlMinutes } from '@/lib/orders/reservation'
+import { getOrderReservationTtlMinutes } from '@/lib/orders/reservation'
 import {
   calculateDiscountAmount,
   decimalToNumber,
@@ -435,7 +435,9 @@ export async function POST(request: NextRequest) {
         }
 
         const now = new Date()
-        const expiresAt = status === 'PENDING' ? getOrderReservationExpiry(now, reservationTtlMinutes) : null
+        // PENDING orders no longer auto-expire; organizers manage them manually
+        // via the dashboard (reminder flow + manual cancel).
+        const expiresAt = null
 
         const order = await tx.order.create({
           data: {

--- a/src/app/api/orders/send-pending-reminders/route.ts
+++ b/src/app/api/orders/send-pending-reminders/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { sendPendingOrderReminders } from '@/lib/orders/sendPendingReminders'
+
+function isAuthorized(request: NextRequest): boolean {
+  const expectedToken = process.env.ORDER_CLEANUP_TOKEN
+  if (!expectedToken) return true
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length) === expectedToken
+  }
+
+  return request.headers.get('x-cleanup-token') === expectedToken
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!isAuthorized(request)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limitParam = searchParams.get('limit')
+    const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+
+    const result = await sendPendingOrderReminders({ limit: parsedLimit })
+
+    return NextResponse.json({ ok: true, ...result })
+  } catch (error) {
+    console.error('Failed to send pending order reminders:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/components/dashboard/OrderDetailView.tsx
+++ b/src/components/dashboard/OrderDetailView.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
+import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
+import { useToast } from '@/components/ui/toaster'
 
 type OrderDetailViewProps = {
   order: {
@@ -20,6 +22,7 @@ type OrderDetailViewProps = {
     currency: string
     createdAt: Date
     invoiceSentAt?: Date | null
+    reminderSentAt?: Date | null
     discountCode?: string | null
     items: Array<{
       id: string
@@ -35,12 +38,15 @@ type OrderDetailViewProps = {
   emailAction: (formData: FormData) => Promise<void>
   markPaidAction?: (formData: FormData) => Promise<void>
   markInvoiceSentAction?: (formData: FormData) => Promise<void>
+  sendReminderAction?: (formData: FormData) => Promise<void>
   deleteOrderAction?: (formData: FormData) => Promise<void>
 }
 
-export function OrderDetailView({ order, refundAction, emailAction, markPaidAction, markInvoiceSentAction, deleteOrderAction }: OrderDetailViewProps) {
+export function OrderDetailView({ order, refundAction, emailAction, markPaidAction, markInvoiceSentAction, sendReminderAction, deleteOrderAction }: OrderDetailViewProps) {
   const isPendingInvoice = order.status === 'PENDING_INVOICE'
   const showMarkInvoiceSent = isPendingInvoice && !order.invoiceSentAt && markInvoiceSentAction
+  const pendingLabel = getPendingOrderLabel(order)
+  const pendingLabelIsReminder = order.reminderSentAt != null
   return (
     <div className="space-y-6">
       <section className="rounded-xl border border-gray-200 bg-white p-6">
@@ -51,6 +57,22 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
         {order.paymentMethod === 'INVOICE' && (
           <p className="mt-2 inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">
             Invoice order, confirm payment externally
+          </p>
+        )}
+        {pendingLabel && (
+          <p
+            className={`mt-2 inline-flex items-center justify-center rounded-full px-3 py-1 text-center text-sm font-medium ${
+              pendingLabelIsReminder
+                ? 'bg-blue-100 text-blue-600'
+                : 'bg-amber-100 text-amber-600'
+            }`}
+          >
+            {pendingLabel}
+            {pendingLabelIsReminder && order.reminderSentAt && (
+              <span className="ml-1 font-normal">
+                on {formatDateTime(order.reminderSentAt)}
+              </span>
+            )}
           </p>
         )}
         {order.paymentMethod === 'FREE' && order.discountCode && (
@@ -118,7 +140,19 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
             <input type="hidden" name="orderId" value={order.id} />
             <Button variant="outline" type="submit">Mark Refund Pending</Button>
           </form>
-          <SendEmailButton orderId={order.id} action={emailAction} />
+          <SendEmailButton
+            orderId={order.id}
+            action={emailAction}
+            deemphasize={order.status === 'PENDING'}
+          />
+          {order.status === 'PENDING' && sendReminderAction && (
+            <SendReminderButton
+              orderId={order.id}
+              action={sendReminderAction}
+              alreadySent={order.reminderSentAt != null}
+              emphasize
+            />
+          )}
           {deleteOrderAction && (
             <DeleteOrderButton orderId={order.id} action={deleteOrderAction} />
           )}
@@ -128,38 +162,84 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
   )
 }
 
-function SendEmailButton({ orderId, action }: { orderId: string; action: (formData: FormData) => Promise<void> }) {
-  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle')
+function SendEmailButton({
+  orderId,
+  action,
+  deemphasize = false,
+}: {
+  orderId: string
+  action: (formData: FormData) => Promise<void>
+  deemphasize?: boolean
+}) {
+  const [isSending, setIsSending] = useState(false)
+  const showToast = useToast()
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setStatus('sending')
+    setIsSending(true)
     try {
       const formData = new FormData(e.currentTarget)
       await action(formData)
-      setStatus('sent')
-      setTimeout(() => setStatus('idle'), 4000)
+      showToast('Confirmation sent!', 'success')
     } catch {
-      setStatus('error')
-      setTimeout(() => setStatus('idle'), 4000)
+      showToast('Failed to send confirmation', 'error')
+    } finally {
+      setIsSending(false)
     }
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <form onSubmit={handleSubmit}>
-        <input type="hidden" name="orderId" value={orderId} />
-        <Button type="submit" disabled={status === 'sending'}>
-          {status === 'sending' ? 'Sending...' : 'Send Email to Buyer'}
-        </Button>
-      </form>
-      {status === 'sent' && (
-        <span className="text-sm font-medium text-green-600">Email sent!</span>
-      )}
-      {status === 'error' && (
-        <span className="text-sm font-medium text-red-600">Failed to send email</span>
-      )}
-    </div>
+    <form onSubmit={handleSubmit}>
+      <input type="hidden" name="orderId" value={orderId} />
+      <Button type="submit" variant={deemphasize ? 'outline' : 'default'} disabled={isSending}>
+        {isSending ? 'Sending…' : 'Resend order confirmation (tickets + receipt)'}
+      </Button>
+    </form>
+  )
+}
+
+function SendReminderButton({
+  orderId,
+  action,
+  alreadySent,
+  emphasize = false,
+}: {
+  orderId: string
+  action: (formData: FormData) => Promise<void>
+  alreadySent: boolean
+  emphasize?: boolean
+}) {
+  const [isSending, setIsSending] = useState(false)
+  const showToast = useToast()
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (alreadySent && !confirm('A reminder has already been sent for this order. Send another?')) {
+      return
+    }
+    setIsSending(true)
+    try {
+      const formData = new FormData(e.currentTarget)
+      await action(formData)
+      showToast('Reminder sent!', 'success')
+    } catch {
+      showToast('Failed to send reminder', 'error')
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="hidden" name="orderId" value={orderId} />
+      <Button type="submit" variant={emphasize ? 'default' : 'outline'} disabled={isSending}>
+        {isSending
+          ? 'Sending…'
+          : alreadySent
+          ? 'Resend payment reminder'
+          : 'Send payment reminder'}
+      </Button>
+    </form>
   )
 }
 

--- a/src/components/dashboard/OrderDetails.tsx
+++ b/src/components/dashboard/OrderDetails.tsx
@@ -10,6 +10,7 @@ export interface DashboardOrderDetails {
   totalAmount: number
   currency: string
   buyerEmail: string
+  reminderSentAt?: string | null
   items: Array<{
     id: string
     quantity: number

--- a/src/components/dashboard/OrderList.tsx
+++ b/src/components/dashboard/OrderList.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { type DashboardOrderDetails } from '@/components/dashboard/OrderDetails'
+import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
 
 export interface DashboardOrderListItem extends DashboardOrderDetails {
   event: {
@@ -111,6 +112,22 @@ export function OrderList({ orders }: OrderListProps) {
                 <div className="grid gap-2 sm:grid-cols-2">
                   <p>
                     <span className="font-medium text-gray-900">Status:</span> {order.status}
+                    {(() => {
+                      const label = getPendingOrderLabel(order)
+                      if (!label) return null
+                      const isReminded = order.reminderSentAt != null
+                      return (
+                        <span
+                          className={`ml-2 inline-flex items-center justify-center rounded-full px-2 py-0.5 text-center text-xs font-medium ${
+                            isReminded
+                              ? 'bg-blue-100 text-blue-600'
+                              : 'bg-amber-100 text-amber-600'
+                          }`}
+                        >
+                          {label}
+                        </span>
+                      )
+                    })()}
                   </p>
                   <p>
                     <span className="font-medium text-gray-900">Event Date:</span>{' '}

--- a/src/components/dashboard/OrdersTable.tsx
+++ b/src/components/dashboard/OrdersTable.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { OrderStatus, PaymentMethod, DiscountType } from '@prisma/client'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
+import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
 
 type OrdersTableProps = {
   eventId: string
@@ -16,6 +17,7 @@ type OrdersTableProps = {
     totalAmount: number
     currency: string
     createdAt: Date
+    reminderSentAt?: Date | string | null
     discountCode?: {
       code: string
       discountType: DiscountType
@@ -58,7 +60,27 @@ export function OrdersTable({ eventId, orders }: OrdersTableProps) {
                   {order.buyerFirstName} {order.buyerLastName}
                   <p className="text-xs text-gray-500">{order.buyerEmail}</p>
                 </td>
-                <td className="px-4 py-3 text-gray-700">{order.status}</td>
+                <td className="px-4 py-3 text-gray-700">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span>{order.status}</span>
+                    {(() => {
+                      const label = getPendingOrderLabel(order)
+                      if (!label) return null
+                      const isReminded = order.reminderSentAt != null
+                      return (
+                        <span
+                          className={`inline-flex items-center justify-center rounded-full px-2 py-0.5 text-center text-xs font-medium ${
+                            isReminded
+                              ? 'bg-blue-100 text-blue-600'
+                              : 'bg-amber-100 text-amber-600'
+                          }`}
+                        >
+                          {label}
+                        </span>
+                      )
+                    })()}
+                  </div>
+                </td>
                 <td className="px-4 py-3 text-gray-700">
                   {order.paymentMethod === 'INVOICE' ? (
                     <span className="inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">Invoice</span>

--- a/src/components/dashboard/RecentOrders.tsx
+++ b/src/components/dashboard/RecentOrders.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { OrderStatus, PaymentMethod } from '@prisma/client'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
+import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
 
 type RecentOrdersProps = {
   orders: Array<{
@@ -12,6 +13,7 @@ type RecentOrdersProps = {
     currency: string
     buyerEmail: string
     createdAt: Date
+    reminderSentAt?: Date | string | null
     event: {
       id: string
       title: string
@@ -30,27 +32,42 @@ export function RecentOrders({ orders }: RecentOrdersProps) {
         <p className="text-sm text-gray-600">No orders yet.</p>
       ) : (
         <div className="space-y-3">
-          {orders.map((order) => (
-            <div key={order.id} className="rounded-lg border border-gray-100 p-3">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <Link href={`/dashboard/events/${order.event.id}/orders/${order.id}`} className="font-medium text-gray-900 hover:text-[#5C8BD9]">
-                  {order.orderNumber}
-                </Link>
-                <p className="text-sm font-medium text-gray-900">{formatCurrency(order.totalAmount, order.currency)}</p>
+          {orders.map((order) => {
+            const pendingLabel = getPendingOrderLabel(order)
+            const pendingIsReminder = order.reminderSentAt != null
+            return (
+              <div key={order.id} className="rounded-lg border border-gray-100 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <Link href={`/dashboard/events/${order.event.id}/orders/${order.id}`} className="font-medium text-gray-900 hover:text-[#5C8BD9]">
+                    {order.orderNumber}
+                  </Link>
+                  <p className="text-sm font-medium text-gray-900">{formatCurrency(order.totalAmount, order.currency)}</p>
+                </div>
+                <p className="text-sm text-gray-600">{order.event.title}</p>
+                <p className="text-xs text-gray-500">
+                  {order.buyerEmail} · {order.status}
+                  {pendingLabel && (
+                    <span
+                      className={`ml-1 inline-flex items-center justify-center rounded-full px-2 py-0.5 text-center text-xs font-medium ${
+                        pendingIsReminder
+                          ? 'bg-blue-100 text-blue-600'
+                          : 'bg-amber-100 text-amber-600'
+                      }`}
+                    >
+                      {pendingLabel}
+                    </span>
+                  )}
+                  {order.paymentMethod === 'INVOICE' && (
+                    <span className="ml-1 inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">Invoice</span>
+                  )}
+                  {order.paymentMethod === 'FREE' && (
+                    <span className="ml-1 inline-flex rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">Free order</span>
+                  )}
+                  {' · '}{formatDateTime(order.createdAt)}
+                </p>
               </div>
-              <p className="text-sm text-gray-600">{order.event.title}</p>
-              <p className="text-xs text-gray-500">
-                {order.buyerEmail} · {order.status}
-                {order.paymentMethod === 'INVOICE' && (
-                  <span className="ml-1 inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">Invoice</span>
-                )}
-                {order.paymentMethod === 'FREE' && (
-                  <span className="ml-1 inline-flex rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">Free order</span>
-                )}
-                {' · '}{formatDateTime(order.createdAt)}
-              </p>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </section>

--- a/src/components/dashboard/SendPendingRemindersButton.tsx
+++ b/src/components/dashboard/SendPendingRemindersButton.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+type Result = {
+  scanned: number
+  sent: number
+  failed: number
+}
+
+type Props = {
+  action: () => Promise<Result>
+}
+
+export function SendPendingRemindersButton({ action }: Props) {
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+
+  function handleClick() {
+    setMessage(null)
+    startTransition(async () => {
+      try {
+        const result = await action()
+        if (result.scanned === 0) {
+          setMessage('No pending orders older than 5 hours.')
+        } else {
+          setMessage(
+            `Sent ${result.sent} reminder${result.sent === 1 ? '' : 's'}${
+              result.failed > 0 ? ` (${result.failed} failed)` : ''
+            }.`
+          )
+        }
+      } catch (error) {
+        console.error(error)
+        setMessage('Failed to send reminders.')
+      }
+    })
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        className="inline-flex rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? 'Sending…' : 'Send payment reminders'}
+      </button>
+      {message && <p className="text-xs text-gray-600">{message}</p>}
+    </div>
+  )
+}

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -743,6 +743,65 @@ export async function sendAccountDeletionCancelledEmail(email: string): Promise<
   })
 }
 
+export async function sendPendingOrderReminderEmail(
+  email: string,
+  details: {
+    buyerName: string
+    orderNumber: string
+    eventTitle: string
+    eventDate: string
+    eventSlug: string
+  }
+): Promise<void> {
+  const appUrl = getAppUrl()
+  const appName = getAppName()
+  const eventUrl = `${appUrl}/events/${encodeURIComponent(details.eventSlug)}`
+
+  await sendEmail({
+    to: email,
+    subject: `Complete your order for ${details.eventTitle}`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Complete your order</title>
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+          <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h1 style="color: #d97706;">Your tickets aren't secured yet</h1>
+            <p>Hi ${details.buyerName},</p>
+            <p>We noticed you started an order for <strong>${details.eventTitle}</strong> but payment wasn't completed, so your tickets aren't reserved yet.</p>
+
+            <div style="background-color: #fffbeb; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #d97706;">
+              <p><strong>Order Number:</strong> #${details.orderNumber}</p>
+              <p><strong>Event:</strong> ${details.eventTitle}</p>
+              <p><strong>Event Date:</strong> ${details.eventDate}</p>
+            </div>
+
+            <p>To secure your tickets, please return to the event page and place a new order:</p>
+
+            <p style="text-align: center; margin: 30px 0;">
+              <a href="${eventUrl}" style="background-color: #d97706; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+                Go to event page
+              </a>
+            </p>
+
+            <p>Or copy and paste this link into your browser:</p>
+            <p style="word-break: break-all; color: #666;">${eventUrl}</p>
+
+            <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+            <p style="color: #666; font-size: 12px;">
+              If you've already purchased tickets through another order, you can ignore this email.
+            </p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `Hi ${details.buyerName}, your order #${details.orderNumber} for ${details.eventTitle} (${details.eventDate}) wasn't paid, so your tickets aren't secured. Complete a new order: ${eventUrl}. — ${appName}`,
+  })
+}
+
 export async function sendInvoiceOrderNotificationEmail(
   organizerEmail: string,
   details: {

--- a/src/lib/orders/pendingLabel.ts
+++ b/src/lib/orders/pendingLabel.ts
@@ -1,0 +1,7 @@
+export function getPendingOrderLabel(order: {
+  status: string
+  reminderSentAt?: Date | string | null
+}): string | null {
+  if (order.status !== 'PENDING') return null
+  return order.reminderSentAt ? 'Reminder email sent' : 'Awaiting payment'
+}

--- a/src/lib/orders/sendPendingReminders.ts
+++ b/src/lib/orders/sendPendingReminders.ts
@@ -1,0 +1,91 @@
+import { prisma } from '@/lib/db'
+import { sendPendingOrderReminderEmail } from '@/lib/email'
+import { formatDateTime } from '@/lib/utils'
+
+const REMINDER_DELAY_HOURS = 5
+const DEFAULT_LIMIT = 200
+const MAX_LIMIT = 1000
+
+export interface PendingReminderResult {
+  scanned: number
+  sent: number
+  failed: number
+  limit: number
+  runAt: string
+}
+
+function normalizeLimit(limit?: number): number {
+  if (!Number.isFinite(limit) || !limit || limit <= 0) {
+    return DEFAULT_LIMIT
+  }
+  return Math.min(Math.floor(limit), MAX_LIMIT)
+}
+
+export async function sendPendingOrderReminders(options?: {
+  limit?: number
+  eventId?: string
+}): Promise<PendingReminderResult> {
+  const limit = normalizeLimit(options?.limit)
+  const now = new Date()
+  const cutoff = new Date(now.getTime() - REMINDER_DELAY_HOURS * 60 * 60 * 1000)
+
+  const orders = await prisma.order.findMany({
+    where: {
+      status: 'PENDING',
+      paidAt: null,
+      cancelledAt: null,
+      reminderSentAt: null,
+      createdAt: { lte: cutoff },
+      ...(options?.eventId ? { eventId: options.eventId } : {}),
+    },
+    select: {
+      id: true,
+      orderNumber: true,
+      buyerFirstName: true,
+      buyerLastName: true,
+      buyerEmail: true,
+      event: {
+        select: {
+          title: true,
+          slug: true,
+          startDate: true,
+        },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+    take: limit,
+  })
+
+  let sent = 0
+  let failed = 0
+
+  for (const order of orders) {
+    try {
+      await sendPendingOrderReminderEmail(order.buyerEmail, {
+        buyerName: `${order.buyerFirstName} ${order.buyerLastName}`.trim(),
+        orderNumber: order.orderNumber,
+        eventTitle: order.event.title,
+        eventDate: formatDateTime(order.event.startDate),
+        eventSlug: order.event.slug,
+      })
+
+      await prisma.order.update({
+        where: { id: order.id },
+        data: { reminderSentAt: new Date() },
+      })
+
+      sent += 1
+    } catch (error) {
+      console.error(`Failed to send pending-order reminder for ${order.orderNumber}:`, error)
+      failed += 1
+    }
+  }
+
+  return {
+    scanned: orders.length,
+    sent,
+    failed,
+    limit,
+    runAt: now.toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary

Adds a payment-reminder email flow for `PENDING` (non-invoice) orders so buyers who haven't completed payment can be nudged from the dashboard.

- New `Order.reminderSentAt` column + migration (`20260416112626_add_order_reminder_sent_at`)
- Per-order **Send payment reminder** action on `OrderDetailView` — becomes the primary button when the order is `PENDING`, with the existing "Resend order confirmation" demoted to an outline button so the next useful action is obvious
- Bulk **Send pending reminders** button on the dashboard and orders pages
- New `POST /api/orders/send-pending-reminders` endpoint backed by `lib/orders/sendPendingReminders.ts`
- Pending-order label helper (`lib/orders/pendingLabel.ts`) showing "Awaiting payment" / "Reminder sent on …" on detail and list views
- Reminder email template added to `lib/email`

## Test plan

- [x] Run `prisma migrate deploy` against prod after the app is deployed (per `CLAUDE.md`)
- [x] Create a PENDING order, verify the order detail shows the "Awaiting payment" label and that "Send payment reminder" is now the highlighted button
- [x] Click "Send payment reminder" and confirm the buyer receives the reminder email
- [x] Confirm the detail page now shows "Reminder sent on …" and a confirm dialog appears before sending a second reminder
- [x] From the dashboard / orders page, click **Send pending reminders** and verify all eligible PENDING orders receive a reminder
- [x] Verify PAID / CANCELLED / PENDING_INVOICE orders do not receive reminders