### PR TITLE
fix(dashboard): show ex-VAT breakdown so external invoices don't double-VAT

### DIFF
--- a/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx
@@ -15,6 +15,27 @@ type PageProps = {
   params: Promise<{ id: string; orderId: string }>
 }
 
+// Mirror of the discount label shown on the receipt PDF so the dashboard and
+// receipt stay in sync (see src/lib/pdf/buildReceiptData.ts).
+function buildDiscountLabel(order: {
+  currency: string
+  groupDiscount: { minQuantity: number; discountType: string; discountValue: Prisma.Decimal } | null
+  discountCode: { code: string } | null
+}): string | null {
+  if (order.groupDiscount) {
+    const value = Number(order.groupDiscount.discountValue.toString())
+    const valueLabel =
+      order.groupDiscount.discountType === 'PERCENTAGE'
+        ? `${value}%`
+        : `${value} ${order.currency}`
+    return `group ${order.groupDiscount.minQuantity}+, ${valueLabel} off`
+  }
+  if (order.discountCode) {
+    return `code ${order.discountCode.code}`
+  }
+  return null
+}
+
 export default async function EventOrderDetailPage({ params }: PageProps) {
   await requireOrganizerProfile()
   const { id, orderId } = await params
@@ -36,6 +57,8 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
       subtotal: true,
       discountAmount: true,
       totalAmount: true,
+      vatRate: true,
+      vatAmount: true,
       currency: true,
       createdAt: true,
       invoiceSentAt: true,
@@ -43,6 +66,15 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
       discountCode: {
         select: {
           code: true,
+          discountType: true,
+          discountValue: true,
+        },
+      },
+      groupDiscount: {
+        select: {
+          minQuantity: true,
+          discountType: true,
+          discountValue: true,
         },
       },
       event: {
@@ -535,9 +567,12 @@ export default async function EventOrderDetailPage({ params }: PageProps) {
         subtotal: Number(order.subtotal.toString()),
         discountAmount: Number(order.discountAmount.toString()),
         totalAmount: Number(order.totalAmount.toString()),
+        vatRate: Number(order.vatRate.toString()),
+        vatAmount: Number(order.vatAmount.toString()),
         invoiceSentAt: order.invoiceSentAt,
         reminderSentAt: order.reminderSentAt,
         discountCode: order.discountCode?.code ?? null,
+        discountLabel: buildDiscountLabel(order),
         items: order.items.map((item) => ({
           ...item,
           unitPrice: Number(item.unitPrice.toString()),

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -407,6 +407,18 @@ export async function POST(request: NextRequest) {
                 },
               },
             },
+            groupDiscount: {
+              select: {
+                minQuantity: true,
+                discountType: true,
+                discountValue: true,
+              },
+            },
+            discountCode: {
+              select: {
+                code: true,
+              },
+            },
             event: {
               select: {
                 id: true,
@@ -427,21 +439,34 @@ export async function POST(request: NextRequest) {
     // Notify organizer of the new invoice order
     const organizerEmail = event.organizer.user.email
     if (organizerEmail) {
+      const discountLabel = createdOrder.groupDiscount
+        ? `group ${createdOrder.groupDiscount.minQuantity}+, ${
+            createdOrder.groupDiscount.discountType === 'PERCENTAGE'
+              ? `${Number(createdOrder.groupDiscount.discountValue.toString())}%`
+              : `${Number(createdOrder.groupDiscount.discountValue.toString())} ${createdOrder.currency}`
+          } off`
+        : createdOrder.discountCode
+          ? `code ${createdOrder.discountCode.code}`
+          : null
       await sendInvoiceOrderNotificationEmail(organizerEmail, {
         orderNumber: createdOrder.orderNumber,
         eventTitle: createdOrder.event.title,
         eventId: createdOrder.event.id,
         buyerName: `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`,
         buyerEmail: createdOrder.buyerEmail,
-        totalAmount: createdOrder.totalAmount.toString(),
         currency: createdOrder.currency,
+        subtotal: Number(createdOrder.subtotal.toString()),
+        discountAmount: Number(createdOrder.discountAmount.toString()),
+        discountLabel,
+        vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
+        vatAmount: createdOrder.vatAmount ? Number(createdOrder.vatAmount.toString()) : null,
+        totalAmount: Number(createdOrder.totalAmount.toString()),
         tickets: createdOrder.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
-          price: `${item.totalPrice.toString()} ${createdOrder.currency}`,
+          unitPrice: Number(item.unitPrice.toString()),
+          lineTotal: Number(item.totalPrice.toString()),
         })),
-        vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
-        vatAmount: createdOrder.vatAmount ? createdOrder.vatAmount.toString() : null,
       })
     }
 

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -555,6 +555,18 @@ export async function POST(request: NextRequest) {
               },
             },
             tickets: true,
+            groupDiscount: {
+              select: {
+                minQuantity: true,
+                discountType: true,
+                discountValue: true,
+              },
+            },
+            discountCode: {
+              select: {
+                code: true,
+              },
+            },
             event: {
               select: {
                 id: true,
@@ -626,21 +638,34 @@ export async function POST(request: NextRequest) {
     if (order.status === 'PENDING_INVOICE') {
       const organizerEmail = order.event.organizer?.user?.email
       if (organizerEmail) {
+        const discountLabel = order.groupDiscount
+          ? `group ${order.groupDiscount.minQuantity}+, ${
+              order.groupDiscount.discountType === 'PERCENTAGE'
+                ? `${Number(order.groupDiscount.discountValue.toString())}%`
+                : `${Number(order.groupDiscount.discountValue.toString())} ${order.currency}`
+            } off`
+          : order.discountCode
+            ? `code ${order.discountCode.code}`
+            : null
         await sendInvoiceOrderNotificationEmail(organizerEmail, {
           orderNumber: order.orderNumber,
           eventTitle: order.event.title,
           eventId: order.event.id,
           buyerName: `${order.buyerFirstName} ${order.buyerLastName}`,
           buyerEmail: order.buyerEmail,
-          totalAmount: order.totalAmount.toString(),
           currency: order.currency,
+          subtotal: Number(order.subtotal.toString()),
+          discountAmount: Number(order.discountAmount.toString()),
+          discountLabel,
+          vatRate: order.vatRate ? parseFloat(order.vatRate.toString()) : null,
+          vatAmount: order.vatAmount ? Number(order.vatAmount.toString()) : null,
+          totalAmount: Number(order.totalAmount.toString()),
           tickets: order.items.map((item) => ({
             name: item.ticketType.name,
             quantity: item.quantity,
-            price: `${item.totalPrice.toString()} ${order.currency}`,
+            unitPrice: Number(item.unitPrice.toString()),
+            lineTotal: Number(item.totalPrice.toString()),
           })),
-          vatRate: order.vatRate ? parseFloat(order.vatRate.toString()) : null,
-          vatAmount: order.vatAmount ? order.vatAmount.toString() : null,
         })
       }
     }

--- a/src/components/dashboard/OrderDetailView.tsx
+++ b/src/components/dashboard/OrderDetailView.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
 import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
+import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 import { useToast } from '@/components/ui/toaster'
 
 type OrderDetailViewProps = {
@@ -19,11 +20,14 @@ type OrderDetailViewProps = {
     totalAmount: number
     subtotal: number
     discountAmount: number
+    vatRate: number
+    vatAmount: number
     currency: string
     createdAt: Date
     invoiceSentAt?: Date | null
     reminderSentAt?: Date | null
     discountCode?: string | null
+    discountLabel?: string | null
     items: Array<{
       id: string
       quantity: number
@@ -47,6 +51,25 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
   const showMarkInvoiceSent = isPendingInvoice && !order.invoiceSentAt && markInvoiceSentAction
   const pendingLabel = getPendingOrderLabel(order)
   const pendingLabelIsReminder = order.reminderSentAt != null
+
+  // Stored subtotal/discount/unitPrice/totalPrice are VAT-inclusive (see
+  // src/lib/orders/index.ts:prepareOrderItems). Convert back to ex-VAT so
+  // organizers feeding an external invoicing tool (Fortnox etc.) don't
+  // accidentally treat the gross total as a net base and get double VAT.
+  const hasVat = order.vatRate > 0
+  const toExVat = (vatInclusive: number): number => {
+    if (!hasVat) return vatInclusive
+    return Number(
+      (vatInclusive - getIncludedVatFromVatInclusiveTotal(vatInclusive, order.vatRate)).toFixed(2)
+    )
+  }
+  const subtotalExVat = toExVat(order.subtotal)
+  const discountExVat = toExVat(order.discountAmount)
+  const vatPercent = hasVat ? Math.round(order.vatRate * 100) : 0
+  const discountRowLabel = order.discountLabel
+    ? `Discount (${order.discountLabel})`
+    : 'Discount'
+
   return (
     <div className="space-y-6">
       <section className="rounded-xl border border-gray-200 bg-white p-6">
@@ -98,22 +121,42 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
           </div>
           <div>
             <h2 className="text-sm font-semibold text-gray-900">Totals</h2>
-            <p className="text-sm text-gray-700">Subtotal: {formatCurrency(order.subtotal, order.currency)}</p>
-            <p className="text-sm text-gray-700">Discount: {formatCurrency(order.discountAmount, order.currency)}</p>
-            <p className="text-sm font-semibold text-gray-900">Total: {formatCurrency(order.totalAmount, order.currency)}</p>
+            <p className="text-sm text-gray-700">
+              {hasVat ? 'Subtotal (excl. VAT)' : 'Subtotal'}: {formatCurrency(subtotalExVat, order.currency)}
+            </p>
+            {order.discountAmount > 0 && (
+              <p className="text-sm text-gray-700">
+                {discountRowLabel}: -{formatCurrency(discountExVat, order.currency)}
+              </p>
+            )}
+            {hasVat && (
+              <p className="text-sm text-gray-700">
+                VAT ({vatPercent}%): {formatCurrency(order.vatAmount, order.currency)}
+              </p>
+            )}
+            <p className="text-sm font-semibold text-gray-900">
+              {hasVat ? 'Total (incl. VAT)' : 'Total'}: {formatCurrency(order.totalAmount, order.currency)}
+            </p>
           </div>
         </div>
       </section>
 
       <section className="rounded-xl border border-gray-200 bg-white p-6">
         <h2 className="text-lg font-semibold text-gray-900">Tickets</h2>
+        {hasVat && (
+          <p className="mt-1 text-xs text-gray-500">Unit and line totals shown excl. VAT.</p>
+        )}
         <div className="mt-4 space-y-3">
-          {order.items.map((item) => (
-            <div key={item.id} className="rounded-lg border border-gray-100 p-3 text-sm">
-              <p className="font-medium text-gray-900">{item.ticketType.name}</p>
-              <p className="text-gray-600">Qty {item.quantity} × {formatCurrency(item.unitPrice, order.currency)} = {formatCurrency(item.totalPrice, order.currency)}</p>
-            </div>
-          ))}
+          {order.items.map((item) => {
+            const unitPriceExVat = toExVat(item.unitPrice)
+            const lineTotalExVat = toExVat(item.totalPrice)
+            return (
+              <div key={item.id} className="rounded-lg border border-gray-100 p-3 text-sm">
+                <p className="font-medium text-gray-900">{item.ticketType.name}</p>
+                <p className="text-gray-600">Qty {item.quantity} × {formatCurrency(unitPriceExVat, order.currency)} = {formatCurrency(lineTotalExVat, order.currency)}</p>
+              </div>
+            )
+          })}
         </div>
       </section>
 

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -5,6 +5,7 @@ import { getAppUrl } from '@/lib/url'
 import { prisma } from '@/lib/db'
 import { generateReceiptPdf } from '@/lib/pdf/receipt'
 import { buildReceiptDataForOrder } from '@/lib/pdf/buildReceiptData'
+import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 
 // =============================================================================
 // Email Configuration
@@ -810,24 +811,77 @@ export async function sendInvoiceOrderNotificationEmail(
     eventId: string
     buyerName: string
     buyerEmail: string
-    totalAmount: string
     currency: string
-    tickets: Array<{ name: string; quantity: number; price: string }>
-    vatRate?: number | null
-    vatAmount?: string | null
+    // All money fields are VAT-inclusive (as stored on the Order) — the
+    // function derives the excl-VAT breakdown itself so what the organizer
+    // sees here matches the receipt PDF exactly. This matters because
+    // organizers key these numbers into external invoicing tools (Fortnox
+    // etc.), and reading a gross amount as a net base causes double VAT.
+    subtotal: number
+    discountAmount: number
+    discountLabel?: string | null
+    vatRate: number | null
+    vatAmount: number | null
+    totalAmount: number
+    tickets: Array<{
+      name: string
+      quantity: number
+      unitPrice: number
+      lineTotal: number
+    }>
   }
 ): Promise<void> {
+  const hasVat = details.vatRate != null && details.vatRate > 0
+  const vatRate = details.vatRate ?? 0
+  const toExVat = (vatInclusive: number): number => {
+    if (!hasVat) return vatInclusive
+    return Number(
+      (vatInclusive - getIncludedVatFromVatInclusiveTotal(vatInclusive, vatRate)).toFixed(2)
+    )
+  }
+  const formatMoney = (n: number) => `${n.toFixed(2)} ${details.currency}`
+
+  const subtotalExVat = toExVat(details.subtotal)
+  const discountExVat = toExVat(details.discountAmount)
+  const vatPercent = hasVat ? Math.round(vatRate * 100) : 0
+
+  const unitHeader = hasVat ? 'Unit price (excl. VAT)' : 'Unit price'
+  const lineHeader = hasVat ? 'Amount (excl. VAT)' : 'Amount'
+  const subtotalLabel = hasVat ? 'Subtotal (excl. VAT)' : 'Subtotal'
+  const totalLabel = hasVat ? 'Total (incl. VAT)' : 'Total'
+
   const ticketRows = details.tickets
-    .map(
-      (t) => `
+    .map((t) => {
+      const unit = toExVat(t.unitPrice)
+      const line = toExVat(t.lineTotal)
+      return `
         <tr>
           <td style="padding: 8px; border-bottom: 1px solid #eee;">${t.name}</td>
           <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: center;">${t.quantity}</td>
-          <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">${t.price}</td>
+          <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">${formatMoney(unit)}</td>
+          <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">${formatMoney(line)}</td>
         </tr>
       `
-    )
+    })
     .join('')
+
+  const discountRow = details.discountAmount > 0
+    ? `
+      <tr>
+        <td colspan="3" style="padding: 8px; text-align: right;">${
+          details.discountLabel ? `Discount (${details.discountLabel})` : 'Discount'
+        }:</td>
+        <td style="padding: 8px; text-align: right;">-${formatMoney(discountExVat)}</td>
+      </tr>
+    ` : ''
+
+  const vatRow = hasVat
+    ? `
+      <tr>
+        <td colspan="3" style="padding: 8px; text-align: right;">VAT (${vatPercent}%):</td>
+        <td style="padding: 8px; text-align: right;">${formatMoney(details.vatAmount ?? 0)}</td>
+      </tr>
+    ` : ''
 
   const dashboardUrl = `${getAppUrl()}/dashboard/events/${details.eventId}/orders`
 
@@ -858,25 +912,32 @@ export async function sendInvoiceOrderNotificationEmail(
                 <tr style="background-color: #f1f5f9;">
                   <th style="padding: 8px; text-align: left;">Ticket</th>
                   <th style="padding: 8px; text-align: center;">Qty</th>
-                  <th style="padding: 8px; text-align: right;">Price</th>
+                  <th style="padding: 8px; text-align: right;">${unitHeader}</th>
+                  <th style="padding: 8px; text-align: right;">${lineHeader}</th>
                 </tr>
               </thead>
               <tbody>
                 ${ticketRows}
               </tbody>
               <tfoot>
-                ${details.vatRate && details.vatRate > 0 ? `
                 <tr>
-                  <td colspan="2" style="padding: 8px; text-align: right;">VAT (${Math.round(details.vatRate * 100)}%):</td>
-                  <td style="padding: 8px; text-align: right;">${details.vatAmount ?? '0.00'} ${details.currency}</td>
+                  <td colspan="3" style="padding: 8px; text-align: right;">${subtotalLabel}:</td>
+                  <td style="padding: 8px; text-align: right;">${formatMoney(subtotalExVat)}</td>
                 </tr>
-                ` : ''}
+                ${discountRow}
+                ${vatRow}
                 <tr>
-                  <td colspan="2" style="padding: 8px; text-align: right;"><strong>Total:</strong></td>
-                  <td style="padding: 8px; text-align: right;"><strong>${details.totalAmount} ${details.currency}</strong></td>
+                  <td colspan="3" style="padding: 8px; text-align: right;"><strong>${totalLabel}:</strong></td>
+                  <td style="padding: 8px; text-align: right;"><strong>${formatMoney(details.totalAmount)}</strong></td>
                 </tr>
               </tfoot>
             </table>
+
+            ${hasVat ? `
+            <p style="color: #666; font-size: 12px; margin-top: -10px;">
+              Amounts shown excl. VAT except the grand total. When issuing an external invoice, use the excl-VAT figures as the net base so VAT is not added twice.
+            </p>
+            ` : ''}
 
             <div style="background-color: #fef3c7; padding: 15px; border-radius: 8px; margin: 20px 0;">
               <p style="margin: 0; color: #92400e;">
@@ -898,6 +959,6 @@ export async function sendInvoiceOrderNotificationEmail(
         </body>
       </html>
     `,
-    text: `New Invoice Order #${details.orderNumber} for ${details.eventTitle}. Buyer: ${details.buyerName} (${details.buyerEmail}). Total: ${details.totalAmount} ${details.currency}. View orders: ${dashboardUrl}`,
+    text: `New Invoice Order #${details.orderNumber} for ${details.eventTitle}. Buyer: ${details.buyerName} (${details.buyerEmail}). ${totalLabel}: ${formatMoney(details.totalAmount)}. View orders: ${dashboardUrl}`,
   })
 }


### PR DESCRIPTION
## Summary

Order money fields (`subtotal`, `discountAmount`, `totalAmount`, `OrderItem.unitPrice/totalPrice`) are stored **VAT-inclusive** — `prepareOrderItems` multiplies by `1 + vatRate` ([src/lib/orders/index.ts:85](../blob/main/src/lib/orders/index.ts#L85)). The customer receipt PDF correctly un-wraps these back to ex-VAT subtotal + discount + VAT + incl-VAT total. The organizer-facing surfaces did not:

- **Dashboard `OrderDetailView`** showed `Subtotal / Discount / Total` — all VAT-inclusive numbers, no "incl. VAT" label, no VAT row.
- **"New Invoice Order" email** showed line prices at their VAT-inclusive `totalPrice` plus a separate `VAT` row plus a `Total` row — line prices already included VAT, so the arithmetic didn't hang together.

This caused a real customer-reported double-VAT on an external (Fortnox) invoice: the gross total (18,299.25 SEK) was read off the dashboard, pasted into Fortnox as the pre-VAT net base, and Fortnox added 25% VAT again, producing a "to be paid" of 22,874.06 SEK instead of 18,299.25 SEK.

## What changed

- `src/components/dashboard/OrderDetailView.tsx` — Totals block now renders `Subtotal (excl. VAT) / Discount (label) / VAT (25%) / Total (incl. VAT)`, matching the receipt. Per-ticket rows show `unit × qty = line`, both ex-VAT.
- `src/app/(dashboard)/dashboard/events/[id]/orders/[orderId]/page.tsx` — fetches `vatRate`, `vatAmount`, `groupDiscount`, `discountCode`, and builds a `discountLabel` mirroring `buildReceiptData.ts`.
- `src/lib/email/index.ts` — `sendInvoiceOrderNotificationEmail` signature now takes numeric `subtotal / discountAmount / discountLabel / vatRate / vatAmount / totalAmount` plus per-line `unitPrice / lineTotal`; renders the same ex-VAT breakdown as the receipt and adds a note that ex-VAT figures are what to feed into external invoicing tools.
- `src/app/api/orders/route.ts` and `src/app/api/orders/manual/route.ts` — both call sites include `groupDiscount` + `discountCode` on the returned order and pass the new fields through.

No schema changes, no stored-value changes — purely display-side conversion using the existing `getIncludedVatFromVatInclusiveTotal` helper.

## Test plan

- [ ] Typecheck passes (`npx tsc --noEmit` — only stale `.next/` validator references remain, unrelated).
- [ ] Existing test suite passes (`npx vitest run` — 80/80).
- [ ] Open an invoice-paid order in the dashboard; confirm the Totals block matches the receipt PDF line-for-line.
- [ ] Place a new PENDING_INVOICE order; confirm the organizer notification email shows ex-VAT unit/line, ex-VAT subtotal, ex-VAT discount, VAT row, incl-VAT total that all reconcile.
- [ ] Place a manual invoice order; same check on the notification email.
- [ ] Place an order in a country with 0% VAT; confirm the "(excl. VAT)" / VAT row are hidden and totals behave as before.