### PR TITLE
fix(dashboard): one-way buyer pre-fill + mandatory organization in manual orders

### DIFF
--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -75,7 +75,7 @@ const manualOrderAttendeeSchema = z.object({
   lastName: z.string().min(1, 'Last name is required'),
   email: z.string().email('Invalid email address'),
   title: z.string().optional(),
-  organization: z.string().optional(),
+  organization: z.string().min(1, 'Organization is required'),
 })
 
 const manualOrderItemSchema = z.object({
@@ -92,7 +92,7 @@ const createManualOrderSchema = z.object({
     lastName: z.string().min(1, 'Last name is required'),
     title: z.string().optional(),
     email: z.string().email('Invalid email address'),
-    organization: z.string().optional(),
+    organization: z.string().min(1, 'Organization is required'),
     address: z.string().optional(),
     city: z.string().optional(),
     postalCode: z.string().optional(),

--- a/src/components/dashboard/ManualOrderForm.tsx
+++ b/src/components/dashboard/ManualOrderForm.tsx
@@ -514,11 +514,14 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="buyer-organization">Organization</Label>
+              <Label htmlFor="buyer-organization" required>
+                Organization
+              </Label>
               <Input
                 id="buyer-organization"
                 value={buyer.organization}
                 onChange={(e) => updateBuyerField('organization', e.target.value)}
+                required
               />
             </div>
             <div className="space-y-2 sm:col-span-2">
@@ -660,7 +663,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                               />
                             </div>
                             <div className="space-y-1">
-                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-organization`}>
+                              <Label htmlFor={`attendee-${item.ticketTypeId}-${i}-organization`} required>
                                 Organization
                               </Label>
                               <Input
@@ -669,6 +672,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 onChange={(e) =>
                                   updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
                                 }
+                                required
                               />
                             </div>
                           </div>

--- a/src/components/dashboard/ManualOrderForm.tsx
+++ b/src/components/dashboard/ManualOrderForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -276,11 +276,28 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
     })
   }, [selectedItems])
 
-  // Keep first attendee synced with buyer details
+  // One-way pre-fill: buyer -> first attendee of the first selected ticket type.
+  // Only overwrite fields the user hasn't edited (i.e., still equal to the last synced buyer value).
+  const lastSyncedBuyerRef = useRef({
+    firstName: '',
+    lastName: '',
+    email: '',
+    title: '',
+    organization: '',
+  })
   useEffect(() => {
     if (selectedItems.length === 0) return
 
     const firstTypeId = selectedItems[0].ticketTypeId
+    const prev = lastSyncedBuyerRef.current
+    const nextBuyerSnapshot = {
+      firstName: buyer.firstName,
+      lastName: buyer.lastName,
+      email: buyer.email,
+      title: buyer.title,
+      organization: buyer.organization,
+    }
+    lastSyncedBuyerRef.current = nextBuyerSnapshot
 
     setAttendeesByType((current) => {
       const slots = current[firstTypeId]
@@ -289,11 +306,11 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
       const first = slots[0]
       const nextFirst: AttendeeFormState = {
         ...first,
-        firstName: buyer.firstName,
-        lastName: buyer.lastName,
-        email: buyer.email,
-        title: buyer.title,
-        organization: buyer.organization,
+        firstName: first.firstName === prev.firstName ? buyer.firstName : first.firstName,
+        lastName: first.lastName === prev.lastName ? buyer.lastName : first.lastName,
+        email: first.email === prev.email ? buyer.email : first.email,
+        title: first.title === prev.title ? buyer.title : first.title,
+        organization: first.organization === prev.organization ? buyer.organization : first.organization,
       }
 
       const unchanged =
@@ -365,7 +382,6 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
     }
 
     const buyerEmailValue = buyer.email.trim()
-    const firstSelectedTicketTypeId = selectedItems[0]?.ticketTypeId
 
     if (!buyer.firstName || !buyer.lastName) {
       setSubmitError('First name and last name are required')
@@ -381,18 +397,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
     for (const item of selectedItems) {
       const slots = attendeesByType[item.ticketTypeId] ?? []
       for (let i = 0; i < item.quantity; i++) {
-        const linkedToBuyer = item.ticketTypeId === firstSelectedTicketTypeId && i === 0
-        const a = linkedToBuyer
-          ? {
-              ...(slots[i] ?? emptyAttendee()),
-              firstName: buyer.firstName,
-              lastName: buyer.lastName,
-              email: buyerEmailValue,
-              title: buyer.title,
-              organization: buyer.organization,
-            }
-          : slots[i]
-
+        const a = slots[i]
         if (!a || !a.firstName || !a.lastName || !a.email) {
           const ticketName = ticketTypes.find((t) => t.id === item.ticketTypeId)?.name ?? 'ticket'
           setSubmitError(`Please fill in all attendee details for "${ticketName}" (ticket ${i + 1})`)
@@ -415,21 +420,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
           items: selectedItems.map((item) => ({
             ticketTypeId: item.ticketTypeId,
             quantity: item.quantity,
-            attendees: (attendeesByType[item.ticketTypeId] ?? [])
-              .slice(0, item.quantity)
-              .map((attendee, index) => {
-                const linkedToBuyer = item.ticketTypeId === firstSelectedTicketTypeId && index === 0
-                if (!linkedToBuyer) return attendee
-
-                return {
-                  ...(attendee ?? emptyAttendee()),
-                  firstName: buyer.firstName,
-                  lastName: buyer.lastName,
-                  email: buyerEmailValue,
-                  title: buyer.title,
-                  organization: buyer.organization,
-                }
-              }),
+            attendees: (attendeesByType[item.ticketTypeId] ?? []).slice(0, item.quantity),
           })),
           buyer: {
             ...buyer,
@@ -583,17 +574,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                   <div key={item.ticketTypeId} className="space-y-4">
                     {Array.from({ length: item.quantity }, (_, i) => {
                       const attendee = slots[i] ?? emptyAttendee()
-                      const isBuyerLinkedAttendee = item.ticketTypeId === selectedItems[0]?.ticketTypeId && i === 0
-                      const attendeeDisplay = isBuyerLinkedAttendee
-                        ? {
-                            ...attendee,
-                            firstName: buyer.firstName,
-                            lastName: buyer.lastName,
-                            email: buyer.email,
-                            title: buyer.title,
-                            organization: buyer.organization,
-                          }
-                        : attendee
+                      const attendeeDisplay = attendee
                       const label =
                         item.quantity > 1
                           ? `${ticketType?.name ?? 'Ticket'} #${i + 1}`
@@ -606,7 +587,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                         >
                           <div className="mb-3 flex items-center justify-between gap-2">
                             <p className="text-sm font-medium text-gray-700">{label}</p>
-                            {!isBuyerLinkedAttendee && buyer.firstName && buyer.lastName && buyer.email && (
+                            {buyer.firstName && buyer.lastName && buyer.email && (
                               <button
                                 type="button"
                                 onClick={() => fillAttendeeFromBuyer(item.ticketTypeId, i)}
@@ -628,9 +609,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 id={`attendee-${item.ticketTypeId}-${i}-first-name`}
                                 value={attendeeDisplay.firstName}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('firstName', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
                                 }
                                 required
                               />
@@ -646,9 +625,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 id={`attendee-${item.ticketTypeId}-${i}-last-name`}
                                 value={attendeeDisplay.lastName}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('lastName', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
                                 }
                                 required
                               />
@@ -665,9 +642,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 type="email"
                                 value={attendeeDisplay.email}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('email', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
                                 }
                                 required
                               />
@@ -680,9 +655,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 id={`attendee-${item.ticketTypeId}-${i}-title`}
                                 value={attendeeDisplay.title}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('title', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'title', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'title', e.target.value)
                                 }
                               />
                             </div>
@@ -694,9 +667,7 @@ export function ManualOrderForm({ event, ticketTypes, groupDiscounts = [] }: Man
                                 id={`attendee-${item.ticketTypeId}-${i}-organization`}
                                 value={attendeeDisplay.organization}
                                 onChange={(e) =>
-                                  isBuyerLinkedAttendee
-                                    ? updateBuyerField('organization', e.target.value)
-                                    : updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
+                                  updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
                                 }
                               />
                             </div>


### PR DESCRIPTION
Fixes two manual-order regressions that the customer-facing checkout
already had fixed (#309, #307):

### 1. Buyer ↔ first-attendee pre-fill was two-way
Editing the pre-filled first attendee also mutated the buyer form
(and vice versa). Applying the same pattern as #309:

- Buyer still pre-fills the first ticket's attendee fields, but only
  for fields the user hasn't edited (tracked via a synced-buyer
  `useRef` snapshot).
- Attendee slot is now the single source of truth for every ticket —
  submit payload and validation no longer overlay buyer fields onto
  the first attendee.
- "Fill from buyer details" button is now also available on the
  first ticket.

### 2. Organization was optional
Mirroring #307: buyer and attendee `organization` fields are now
required both in the form UI (HTML `required` + `Label required`)
and in the server Zod schema in `/api/orders/manual`.

## Test plan
- [x] Open `Dashboard > Events > [event] > Orders > New`
- [x] Fill buyer info — first attendee gets pre-filled
- [x] Edit first attendee's name/email — buyer form should NOT change
- [x] Keep editing buyer — only untouched attendee fields update
- [x] "Fill from buyer details" button appears on every ticket and works
- [x] Leave buyer or attendee organization blank — submit is blocked
- [x] Submit succeeds when all organization fields are filled