### PR TITLE
feat(email): send each attendee their own ticket email

### DIFF
--- a/src/app/api/orders/[id]/capture/route.ts
+++ b/src/app/api/orders/[id]/capture/route.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from 'next/cache'
 import { Prisma, PaymentMethod } from '@prisma/client'
 import { getCurrentUser } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { sendOrderConfirmationEmail } from '@/lib/email'
+import { sendOrderConfirmationEmail, sendAttendeeTicketEmailsForOrder } from '@/lib/email'
 import { canAccessOrder } from '@/lib/orders/authorization'
 import { capturePayment, getPaymentStatus } from '@/lib/payments'
 import { generateTicketCreateInput, lockTicketTypes } from '@/lib/orders'
@@ -275,32 +275,61 @@ export async function GET(request: NextRequest, context: RouteContext) {
       }
     )
 
+    const eventLocation =
+      paidOrder.event.locationType === 'ONLINE'
+        ? paidOrder.event.onlineUrl || 'Online event'
+        : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
+            .filter(Boolean)
+            .join(', ')
+    const eventDate = formatDateTime(paidOrder.event.startDate)
+    const buyerName = `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`
+    const paidOrderTickets = (paidOrder as typeof paidOrder & {
+      tickets: Array<{
+        ticketCode: string
+        ticketTypeId: string
+        attendeeFirstName: string | null
+        attendeeLastName: string | null
+        attendeeEmail: string | null
+      }>
+    }).tickets
+
     // Email failures must not fail a successful payment flow.
     try {
       await sendOrderConfirmationEmail(paidOrder.buyerEmail, {
         orderNumber: paidOrder.orderNumber,
         orderId: paidOrder.id,
         eventTitle: paidOrder.event.title,
-        eventDate: formatDateTime(paidOrder.event.startDate),
-        eventLocation:
-          paidOrder.event.locationType === 'ONLINE'
-            ? paidOrder.event.onlineUrl || 'Online event'
-            : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
-                .filter(Boolean)
-                .join(', '),
+        eventDate,
+        eventLocation,
         tickets: paidOrder.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
           price: `${item.totalPrice.toString()} ${paidOrder.currency}`,
         })),
         totalAmount: `${paidOrder.totalAmount.toString()} ${paidOrder.currency}`,
-        buyerName: `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`,
+        buyerName,
         vatRate: parseFloat(paidOrder.vatRate.toString()),
         vatAmount: paidOrder.vatAmount.toString(),
-        ticketCodes: (paidOrder as typeof paidOrder & { tickets: Array<{ ticketCode: string }> }).tickets.map((t) => t.ticketCode),
+        ticketCodes: paidOrderTickets.map((t) => t.ticketCode),
       })
     } catch (emailError) {
       console.error('[Capture] Confirmation email failed after successful payment:', emailError)
+    }
+
+    // Send each non-buyer attendee their own ticket email
+    try {
+      await sendAttendeeTicketEmailsForOrder({
+        orderNumber: paidOrder.orderNumber,
+        buyerEmail: paidOrder.buyerEmail,
+        buyerName,
+        eventTitle: paidOrder.event.title,
+        eventDate,
+        eventLocation,
+        tickets: paidOrderTickets,
+        items: paidOrder.items,
+      })
+    } catch (emailError) {
+      console.error('[Capture] Attendee ticket emails failed after successful payment:', emailError)
     }
 
     revalidateTag('event-analytics', 'max')

--- a/src/app/api/orders/[id]/mark-paid/route.ts
+++ b/src/app/api/orders/[id]/mark-paid/route.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from 'next/cache'
 import { Prisma, PaymentMethod } from '@prisma/client'
 import { requireAuth } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { sendOrderConfirmationEmail } from '@/lib/email'
+import { sendOrderConfirmationEmail, sendAttendeeTicketEmailsForOrder } from '@/lib/email'
 import { generateTicketCreateInput, lockTicketTypes } from '@/lib/orders'
 import { formatDateTime } from '@/lib/utils'
 
@@ -195,28 +195,53 @@ export async function POST(request: NextRequest, context: RouteContext) {
       }
     )
 
-    // Send confirmation email to buyer
+    const eventLocation =
+      paidOrder.event.locationType === 'ONLINE'
+        ? paidOrder.event.onlineUrl || 'Online event'
+        : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
+            .filter(Boolean)
+            .join(', ')
+    const eventDate = formatDateTime(paidOrder.event.startDate)
+    const buyerName = `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`
+    const paidOrderTickets = (paidOrder as typeof paidOrder & {
+      tickets: Array<{
+        ticketCode: string
+        ticketTypeId: string
+        attendeeFirstName: string | null
+        attendeeLastName: string | null
+        attendeeEmail: string | null
+      }>
+    }).tickets
+
+    // Send confirmation email to buyer (full receipt + all tickets)
     await sendOrderConfirmationEmail(paidOrder.buyerEmail, {
       orderNumber: paidOrder.orderNumber,
       orderId: paidOrder.id,
       eventTitle: paidOrder.event.title,
-      eventDate: formatDateTime(paidOrder.event.startDate),
-      eventLocation:
-        paidOrder.event.locationType === 'ONLINE'
-          ? paidOrder.event.onlineUrl || 'Online event'
-          : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
-              .filter(Boolean)
-              .join(', '),
+      eventDate,
+      eventLocation,
       tickets: paidOrder.items.map((item) => ({
         name: item.ticketType.name,
         quantity: item.quantity,
         price: `${item.totalPrice.toString()} ${paidOrder.currency}`,
       })),
       totalAmount: `${paidOrder.totalAmount.toString()} ${paidOrder.currency}`,
-      buyerName: `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`,
+      buyerName,
       vatRate: parseFloat(paidOrder.vatRate.toString()),
       vatAmount: paidOrder.vatAmount.toString(),
-      ticketCodes: (paidOrder as typeof paidOrder & { tickets: Array<{ ticketCode: string }> }).tickets.map((t) => t.ticketCode),
+      ticketCodes: paidOrderTickets.map((t) => t.ticketCode),
+    })
+
+    // Send each non-buyer attendee their own ticket email
+    await sendAttendeeTicketEmailsForOrder({
+      orderNumber: paidOrder.orderNumber,
+      buyerEmail: paidOrder.buyerEmail,
+      buyerName,
+      eventTitle: paidOrder.event.title,
+      eventDate,
+      eventLocation,
+      tickets: paidOrderTickets,
+      items: paidOrder.items,
     })
 
     revalidateTag('event-analytics', 'max')

--- a/src/app/api/orders/[id]/pay/route.ts
+++ b/src/app/api/orders/[id]/pay/route.ts
@@ -4,7 +4,7 @@ import { Prisma, PaymentMethod } from '@prisma/client'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { sendOrderConfirmationEmail } from '@/lib/email'
+import { sendOrderConfirmationEmail, sendAttendeeTicketEmailsForOrder } from '@/lib/email'
 import { canAccessOrder } from '@/lib/orders/authorization'
 import {
   createPaymentIntent,
@@ -274,6 +274,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
             unitPrice: Number(item.unitPrice),
             totalPrice: Number(item.totalPrice),
             currency: latestOrder.currency,
+            attendees: Array.isArray(item.attendeeData)
+              ? (item.attendeeData as unknown as import('@/lib/orders').AttendeeData[])
+              : undefined,
           }))
         )
 
@@ -315,32 +318,52 @@ export async function POST(request: NextRequest, context: RouteContext) {
       }
     )
 
+    const eventLocation =
+      paidOrder.event.locationType === 'ONLINE'
+        ? paidOrder.event.onlineUrl || 'Online event'
+        : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
+            .filter(Boolean)
+            .join(', ')
+    const eventDate = formatDateTime(paidOrder.event.startDate)
+    const buyerName = `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`
+
     // Email failures must not fail a successful payment flow.
     try {
       await sendOrderConfirmationEmail(paidOrder.buyerEmail, {
         orderNumber: paidOrder.orderNumber,
         orderId: paidOrder.id,
         eventTitle: paidOrder.event.title,
-        eventDate: formatDateTime(paidOrder.event.startDate),
-        eventLocation:
-          paidOrder.event.locationType === 'ONLINE'
-            ? paidOrder.event.onlineUrl || 'Online event'
-            : [paidOrder.event.venue, paidOrder.event.city, paidOrder.event.country]
-                .filter(Boolean)
-                .join(', '),
+        eventDate,
+        eventLocation,
         tickets: paidOrder.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
           price: `${item.totalPrice.toString()} ${paidOrder.currency}`,
         })),
         totalAmount: `${paidOrder.totalAmount.toString()} ${paidOrder.currency}`,
-        buyerName: `${paidOrder.buyerFirstName} ${paidOrder.buyerLastName}`,
+        buyerName,
         vatRate: parseFloat(paidOrder.vatRate.toString()),
         vatAmount: paidOrder.vatAmount.toString(),
         ticketCodes: paidOrder.tickets.map((t) => t.ticketCode),
       })
     } catch (emailError) {
       console.error('[Pay] Confirmation email failed after successful payment:', emailError)
+    }
+
+    // Send each non-buyer attendee their own ticket email
+    try {
+      await sendAttendeeTicketEmailsForOrder({
+        orderNumber: paidOrder.orderNumber,
+        buyerEmail: paidOrder.buyerEmail,
+        buyerName,
+        eventTitle: paidOrder.event.title,
+        eventDate,
+        eventLocation,
+        tickets: paidOrder.tickets,
+        items: paidOrder.items,
+      })
+    } catch (emailError) {
+      console.error('[Pay] Attendee ticket emails failed after successful payment:', emailError)
     }
 
     revalidateTag('event-analytics', 'max')

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -3,7 +3,11 @@ import { revalidateTag } from 'next/cache'
 import { Prisma } from '@prisma/client'
 import { getSession } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { sendOrderConfirmationEmail, sendInvoiceOrderNotificationEmail } from '@/lib/email'
+import {
+  sendOrderConfirmationEmail,
+  sendInvoiceOrderNotificationEmail,
+  sendAttendeeTicketEmailsForOrder,
+} from '@/lib/email'
 import { lockTicketTypes, prepareOrderItems, generateTicketCreateInput } from '@/lib/orders'
 import { claimDiscountCodeUsage, getDiscountUsageUnitsFromItems } from '@/lib/orders/discountUsage'
 import {
@@ -610,27 +614,43 @@ export async function POST(request: NextRequest) {
     revalidateTag('dashboard-analytics', 'max')
 
     if (order.status === 'PAID') {
+      const eventLocation =
+        order.event.locationType === 'ONLINE'
+          ? order.event.onlineUrl || 'Online event'
+          : [order.event.venue, order.event.city, order.event.country]
+              .filter(Boolean)
+              .join(', ')
+      const eventDate = formatDateTime(order.event.startDate)
+      const buyerName = `${order.buyerFirstName} ${order.buyerLastName}`
+
       await sendOrderConfirmationEmail(order.buyerEmail, {
         orderNumber: order.orderNumber,
         orderId: order.id,
         eventTitle: order.event.title,
-        eventDate: formatDateTime(order.event.startDate),
-        eventLocation:
-          order.event.locationType === 'ONLINE'
-            ? order.event.onlineUrl || 'Online event'
-            : [order.event.venue, order.event.city, order.event.country]
-                .filter(Boolean)
-                .join(', '),
+        eventDate,
+        eventLocation,
         tickets: order.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
           price: `${item.totalPrice.toString()} ${order.currency}`,
         })),
         totalAmount: `${order.totalAmount.toString()} ${order.currency}`,
-        buyerName: `${order.buyerFirstName} ${order.buyerLastName}`,
+        buyerName,
         vatRate: parseFloat(order.vatRate.toString()),
         vatAmount: order.vatAmount.toString(),
         ticketCodes: order.tickets.map((t) => t.ticketCode),
+      })
+
+      // Send each non-buyer attendee their own ticket email
+      await sendAttendeeTicketEmailsForOrder({
+        orderNumber: order.orderNumber,
+        buyerEmail: order.buyerEmail,
+        buyerName,
+        eventTitle: order.event.title,
+        eventDate,
+        eventLocation,
+        tickets: order.tickets,
+        items: order.items,
       })
     }
 

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -481,6 +481,227 @@ export async function sendOrderConfirmationEmail(
   })
 }
 
+async function generateAttendeeTicketPdf(details: {
+  orderNumber: string
+  eventTitle: string
+  eventDate: string
+  eventLocation: string
+  attendeeName: string
+  tickets: Array<{ name: string; ticketCode: string }>
+}): Promise<Buffer> {
+  const qrBuffers: Buffer[] = []
+  for (const t of details.tickets) {
+    const buf = await QRCode.toBuffer(t.ticketCode, { type: 'png', width: 150, margin: 1 })
+    qrBuffers.push(buf)
+  }
+
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50, size: 'A4' })
+    const chunks: Buffer[] = []
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk))
+    doc.on('end', () => resolve(Buffer.concat(chunks)))
+    doc.on('error', reject)
+
+    doc.fontSize(22).font('Helvetica-Bold').text('Your Ticket', { align: 'center' })
+    doc.moveDown(0.5)
+    doc.fontSize(12).font('Helvetica').text(`Order #${details.orderNumber}`, { align: 'center' })
+    doc.moveDown(1.5)
+
+    doc.fontSize(14).font('Helvetica-Bold').text('Event Details')
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).stroke()
+    doc.moveDown(0.4)
+    doc.fontSize(11).font('Helvetica')
+    doc.text(`Event:     ${details.eventTitle}`)
+    doc.text(`Date:      ${details.eventDate}`)
+    doc.text(`Location:  ${details.eventLocation}`)
+    doc.moveDown(1.2)
+
+    doc.fontSize(14).font('Helvetica-Bold').text('Attendee')
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).stroke()
+    doc.moveDown(0.4)
+    doc.fontSize(11).font('Helvetica').text(details.attendeeName)
+    doc.moveDown(1.2)
+
+    doc.fontSize(14).font('Helvetica-Bold').text(
+      details.tickets.length > 1
+        ? 'Your tickets - present the QR code(s) below at the door'
+        : 'Your ticket - present the QR code below at the door'
+    )
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).stroke()
+    doc.moveDown(0.6)
+
+    for (let i = 0; i < qrBuffers.length; i++) {
+      const t = details.tickets[i]
+      const ticketY = doc.y
+      doc.image(qrBuffers[i], 50, ticketY, { width: 80, height: 80 })
+      doc.fontSize(11).font('Helvetica-Bold').text(t.name, 150, ticketY)
+      doc.fontSize(9).font('Helvetica').text(t.ticketCode, 150, ticketY + 16, { width: 370 })
+      doc.y = ticketY + 90
+      doc.moveDown(0.3)
+    }
+
+    doc.end()
+  })
+}
+
+export async function sendAttendeeTicketEmail(
+  email: string,
+  details: {
+    orderNumber: string
+    eventTitle: string
+    eventDate: string
+    eventLocation: string
+    attendeeName: string
+    buyerName: string
+    tickets: Array<{ name: string; ticketCode: string }>
+  }
+): Promise<void> {
+  const pdfBuffer = await generateAttendeeTicketPdf(details)
+  const multiple = details.tickets.length > 1
+
+  const ticketRows = details.tickets
+    .map(
+      (t) => `
+        <tr>
+          <td style="padding: 10px; border-bottom: 1px solid #eee;">${t.name}</td>
+          <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: right; font-family: monospace;">${t.ticketCode}</td>
+        </tr>
+      `
+    )
+    .join('')
+
+  await sendEmail({
+    to: email,
+    subject: `Your ticket${multiple ? 's' : ''} for ${details.eventTitle}`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Your ticket</title>
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+          <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h1 style="color: #2563eb;">You're going to ${details.eventTitle}!</h1>
+            <p>Hi ${details.attendeeName},</p>
+            <p>${details.buyerName} booked ${multiple ? 'tickets' : 'a ticket'} for you. Your ${multiple ? 'tickets are' : 'ticket is'} attached as a PDF — present the QR code${multiple ? 's' : ''} at the door.</p>
+
+            <div style="background-color: #f8fafc; padding: 20px; border-radius: 8px; margin: 20px 0;">
+              <h2 style="margin-top: 0; color: #1e40af;">${details.eventTitle}</h2>
+              <p><strong>Date:</strong> ${details.eventDate}</p>
+              <p><strong>Location:</strong> ${details.eventLocation}</p>
+              <p><strong>Order Number:</strong> #${details.orderNumber}</p>
+            </div>
+
+            <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+              <thead>
+                <tr style="background-color: #f1f5f9;">
+                  <th style="padding: 10px; text-align: left;">Ticket</th>
+                  <th style="padding: 10px; text-align: right;">Code</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${ticketRows}
+              </tbody>
+            </table>
+
+            <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+            <p style="color: #666; font-size: 12px;">
+              This email contains only your ticket${multiple ? 's' : ''}. For order receipts or billing questions, please contact ${details.buyerName} or the event organizer.
+            </p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `Hi ${details.attendeeName}, ${details.buyerName} booked ${multiple ? 'tickets' : 'a ticket'} for you for ${details.eventTitle} on ${details.eventDate}. Your ticket${multiple ? 's are' : ' is'} attached as a PDF.`,
+    attachments: [
+      {
+        filename: `ticket-${details.orderNumber}.pdf`,
+        content: pdfBuffer,
+        contentType: 'application/pdf',
+      },
+    ],
+  })
+}
+
+/**
+ * Group an order's tickets by attendee email and send each non-buyer attendee
+ * their own ticket email (with just their QR code(s)). The buyer already
+ * receives all tickets via sendOrderConfirmationEmail, so attendees whose
+ * email matches the buyer's are skipped. Individual failures are logged but
+ * don't throw — one attendee's bad email shouldn't block the rest.
+ */
+export async function sendAttendeeTicketEmailsForOrder(params: {
+  orderNumber: string
+  buyerEmail: string
+  buyerName: string
+  eventTitle: string
+  eventDate: string
+  eventLocation: string
+  tickets: Array<{
+    ticketCode: string
+    ticketTypeId: string
+    attendeeFirstName: string | null
+    attendeeLastName: string | null
+    attendeeEmail: string | null
+  }>
+  items: Array<{ ticketTypeId: string; ticketType: { name: string } }>
+}): Promise<void> {
+  const typeNameById = new Map(params.items.map((i) => [i.ticketTypeId, i.ticketType.name]))
+  const buyerKey = params.buyerEmail.trim().toLowerCase()
+
+  const groups = new Map<
+    string,
+    {
+      email: string
+      attendeeName: string
+      tickets: Array<{ name: string; ticketCode: string }>
+    }
+  >()
+
+  for (const ticket of params.tickets) {
+    const rawEmail = ticket.attendeeEmail?.trim()
+    if (!rawEmail) continue
+    const key = rawEmail.toLowerCase()
+    if (key === buyerKey) continue
+
+    const name =
+      [ticket.attendeeFirstName, ticket.attendeeLastName].filter(Boolean).join(' ').trim() ||
+      'Attendee'
+    const ticketTypeName = typeNameById.get(ticket.ticketTypeId) ?? 'Ticket'
+
+    const existing = groups.get(key)
+    if (existing) {
+      existing.tickets.push({ name: ticketTypeName, ticketCode: ticket.ticketCode })
+    } else {
+      groups.set(key, {
+        email: rawEmail,
+        attendeeName: name,
+        tickets: [{ name: ticketTypeName, ticketCode: ticket.ticketCode }],
+      })
+    }
+  }
+
+  for (const group of groups.values()) {
+    try {
+      await sendAttendeeTicketEmail(group.email, {
+        orderNumber: params.orderNumber,
+        eventTitle: params.eventTitle,
+        eventDate: params.eventDate,
+        eventLocation: params.eventLocation,
+        attendeeName: group.attendeeName,
+        buyerName: params.buyerName,
+        tickets: group.tickets,
+      })
+    } catch (error) {
+      console.error(
+        `Failed to send attendee ticket email to ${group.email} for order ${params.orderNumber}:`,
+        error
+      )
+    }
+  }
+}
+
 export async function sendEventCancellationEmail(
   email: string,
   details: {


### PR DESCRIPTION
Previously only the buyer received the order confirmation with all
tickets attached as a PDF. Attendees whose email differed from the
buyer's never got anything, so the buyer had to forward tickets
manually.

Now, in addition to the buyer's full confirmation (receipt + all
tickets — unchanged), every non-buyer attendee automatically
receives a dedicated email at the address entered during checkout,
containing **only their own ticket(s)** and QR code(s) as a PDF
attachment. No prices, no receipt, no financial info.

Applies to **all order completion paths**, so both user-initiated
and manual orders are covered:

- POST /api/orders (free orders that go straight to PAID)
- POST /api/orders/[id]/pay (stub-mode payment capture)
- GET  /api/orders/[id]/capture (Stripe/PayPal return)
- POST /api/orders/[id]/mark-paid (organizer marks invoice paid —
  this is the path manual orders take)

### Behavior
- Attendees whose email matches the buyer's are skipped (the buyer
  already has all tickets).
- Multiple tickets assigned to the same attendee email are grouped
  into one email.
- Empty attendee emails are skipped.
- Per-attendee failures are caught and logged; one bad address
  doesn't block the rest of the sends, and attendee-email failures
  never fail the successful payment flow.

### Latent bug also fixed
`/api/orders/[id]/pay` (stub capture path) wasn't forwarding
`attendeeData` from `OrderItem` to `generateTicketCreateInput`, so
per-ticket attendee fields were empty on stub-mode orders. The other
three paths were already doing this correctly. Without this fix,
stub-mode orders would have no attendee addresses to send to.

## Test plan
- [x] Create a manual order in the dashboard with 2 different
      attendee emails (one of them the buyer's, one different).
      Mark as paid. Verify buyer gets full confirmation; the other
      attendee gets a ticket-only PDF.
- [x] Place a normal (paid) customer checkout with 3 attendees, all
      different emails. Verify each non-buyer attendee gets their
      ticket, and the buyer gets the full confirmation.
- [x] Place a free-ticket order. Same behavior.
- [x] Place an order where two attendees share the same (non-buyer)
      email. Verify they receive a single email with both tickets.
- [x] Verify the attached PDF has QR codes but no prices or receipt.