### PR TITLE
fix(orders): never invoice a zero-total order

### DIFF
--- a/scripts/backfill-free-orders-payment-method.ts
+++ b/scripts/backfill-free-orders-payment-method.ts
@@ -1,0 +1,70 @@
+/*
+ * One-off backfill: any historical order whose totalAmount is 0 should have
+ * paymentMethod=FREE (not INVOICE/PAYPAL). Mirrors the principle "we never
+ * invoice anyone for a free order" introduced in the order-creation routes.
+ *
+ * Usage:
+ *   OE_TARGET=dev  npx tsx scripts/backfill-free-orders-payment-method.ts
+ *   OE_TARGET=prod npx tsx scripts/backfill-free-orders-payment-method.ts
+ *
+ * By default runs in dry-run mode. Add OE_APPLY=1 to actually write.
+ */
+import { PrismaClient } from '@prisma/client'
+
+const target = process.env.OE_TARGET ?? 'dev'
+const apply = process.env.OE_APPLY === '1'
+
+const url =
+  target === 'prod'
+    ? 'postgresql://openevents:OpenEvents2026!@172.232.131.169:10596/openevents'
+    : 'postgresql://openevents:OpenEventsDev2026!@172.232.137.101:10533/openevents'
+
+const prisma = new PrismaClient({ datasources: { db: { url } } })
+
+async function main() {
+  const candidates = await prisma.order.findMany({
+    where: {
+      totalAmount: 0,
+      paymentMethod: { not: 'FREE' },
+    },
+    select: {
+      id: true,
+      orderNumber: true,
+      status: true,
+      paymentMethod: true,
+      totalAmount: true,
+      buyerEmail: true,
+      createdAt: true,
+      discountCode: { select: { code: true, discountType: true } },
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  console.log(`Target: ${target}  Apply: ${apply}`)
+  console.log(`Found ${candidates.length} zero-total orders not marked FREE.`)
+  for (const o of candidates) {
+    console.log(
+      `  ${o.orderNumber}  status=${o.status}  paymentMethod=${o.paymentMethod}  ` +
+        `code=${o.discountCode?.code ?? '-'}(${o.discountCode?.discountType ?? '-'})  ${o.buyerEmail}`
+    )
+  }
+
+  if (!apply) {
+    console.log('\nDry run only. Re-run with OE_APPLY=1 to update paymentMethod=FREE and status=PAID.')
+    return
+  }
+
+  for (const o of candidates) {
+    await prisma.order.update({
+      where: { id: o.id },
+      data: {
+        paymentMethod: 'FREE',
+        status: 'PAID',
+        paidAt: o.status === 'PAID' ? undefined : new Date(),
+      },
+    })
+    console.log(`Updated ${o.orderNumber}`)
+  }
+}
+
+main().finally(() => prisma.$disconnect())

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -3,8 +3,12 @@ import { revalidateTag } from 'next/cache'
 import { Prisma } from '@prisma/client'
 import { requireAuth } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { sendInvoiceOrderNotificationEmail } from '@/lib/email'
-import { lockTicketTypes, prepareOrderItems } from '@/lib/orders'
+import {
+  sendInvoiceOrderNotificationEmail,
+  sendOrderConfirmationEmail,
+  sendAttendeeTicketEmailsForOrder,
+} from '@/lib/email'
+import { generateTicketCreateInput, lockTicketTypes, prepareOrderItems } from '@/lib/orders'
 import { claimDiscountCodeUsage, getDiscountUsageUnitsFromItems } from '@/lib/orders/discountUsage'
 import {
   calculateDiscountAmount,
@@ -13,7 +17,7 @@ import {
   getDiscountCodeRemainingTicketUses,
   normalizeDiscountCode,
 } from '@/lib/tickets'
-import { generateOrderNumber } from '@/lib/utils'
+import { formatDateTime, generateOrderNumber } from '@/lib/utils'
 import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
 import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 import { z } from 'zod'
@@ -324,6 +328,12 @@ export async function POST(request: NextRequest) {
         const totalAmount = Number(Math.max(0, subtotal - discountAmount).toFixed(2))
         const vatAmount = getIncludedVatFromVatInclusiveTotal(totalAmount, vatRate)
 
+        // Free manual orders skip the invoice flow entirely — we don't invoice
+        // anyone for a zero-total order.
+        const isFreeOrder = totalAmount === 0
+        const orderStatus = isFreeOrder ? 'PAID' : 'PENDING_INVOICE'
+        const orderPaymentMethod = isFreeOrder ? 'FREE' : 'INVOICE'
+
         const order = await tx.order.create({
           data: {
             orderNumber: generateOrderNumber(),
@@ -346,9 +356,10 @@ export async function POST(request: NextRequest) {
             vatRate,
             vatAmount,
             currency: ticketTypes[0]?.currency ?? 'SEK',
-            status: 'PENDING_INVOICE',
-            paymentMethod: 'INVOICE',
-            expiresAt: null, // Invoice orders don't expire
+            status: orderStatus,
+            paymentMethod: orderPaymentMethod,
+            expiresAt: null,
+            paidAt: isFreeOrder ? new Date() : null,
           },
         })
 
@@ -373,14 +384,32 @@ export async function POST(request: NextRequest) {
           })
         }
 
-        // Reserve tickets
-        for (const item of preparedOrder.items) {
-          await tx.ticketType.update({
-            where: { id: item.ticketTypeId },
-            data: {
-              reservedCount: { increment: item.quantity },
-            },
-          })
+        if (isFreeOrder) {
+          // Free manual orders complete immediately: count as sold and mint tickets.
+          for (const item of preparedOrder.items) {
+            await tx.ticketType.update({
+              where: { id: item.ticketTypeId },
+              data: { soldCount: { increment: item.quantity } },
+            })
+          }
+
+          const ticketCreateData = generateTicketCreateInput(
+            order.id,
+            preparedOrder.items.map((item) => ({
+              ...item,
+              attendees: attendeesByTicketType.get(item.ticketTypeId),
+            }))
+          )
+          if (ticketCreateData.length > 0) {
+            await tx.ticket.createMany({ data: ticketCreateData })
+          }
+        } else {
+          for (const item of preparedOrder.items) {
+            await tx.ticketType.update({
+              where: { id: item.ticketTypeId },
+              data: { reservedCount: { increment: item.quantity } },
+            })
+          }
         }
 
         // Claim discount code usage if the promo code was applied
@@ -407,6 +436,7 @@ export async function POST(request: NextRequest) {
                 },
               },
             },
+            tickets: true,
             groupDiscount: {
               select: {
                 minQuantity: true,
@@ -423,6 +453,12 @@ export async function POST(request: NextRequest) {
               select: {
                 id: true,
                 title: true,
+                startDate: true,
+                locationType: true,
+                venue: true,
+                city: true,
+                country: true,
+                onlineUrl: true,
               },
             },
           },
@@ -436,38 +472,79 @@ export async function POST(request: NextRequest) {
     revalidateTag('event-analytics', 'max')
     revalidateTag('dashboard-analytics', 'max')
 
-    // Notify organizer of the new invoice order
-    const organizerEmail = event.organizer.user.email
-    if (organizerEmail) {
-      const discountLabel = createdOrder.groupDiscount
-        ? `group ${createdOrder.groupDiscount.minQuantity}+, ${
-            createdOrder.groupDiscount.discountType === 'PERCENTAGE'
-              ? `${Number(createdOrder.groupDiscount.discountValue.toString())}%`
-              : `${Number(createdOrder.groupDiscount.discountValue.toString())} ${createdOrder.currency}`
-          } off`
-        : createdOrder.discountCode
-          ? `code ${createdOrder.discountCode.code}`
-          : null
-      await sendInvoiceOrderNotificationEmail(organizerEmail, {
+    if (createdOrder.status === 'PAID' && createdOrder.paymentMethod === 'FREE') {
+      // Free manual order: send the buyer their confirmation + tickets directly.
+      const eventLocation =
+        createdOrder.event.locationType === 'ONLINE'
+          ? createdOrder.event.onlineUrl || 'Online event'
+          : [createdOrder.event.venue, createdOrder.event.city, createdOrder.event.country]
+              .filter(Boolean)
+              .join(', ')
+      const eventDate = formatDateTime(createdOrder.event.startDate)
+      const buyerName = `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`
+
+      await sendOrderConfirmationEmail(createdOrder.buyerEmail, {
         orderNumber: createdOrder.orderNumber,
+        orderId: createdOrder.id,
         eventTitle: createdOrder.event.title,
-        eventId: createdOrder.event.id,
-        buyerName: `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`,
-        buyerEmail: createdOrder.buyerEmail,
-        currency: createdOrder.currency,
-        subtotal: Number(createdOrder.subtotal.toString()),
-        discountAmount: Number(createdOrder.discountAmount.toString()),
-        discountLabel,
-        vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
-        vatAmount: createdOrder.vatAmount ? Number(createdOrder.vatAmount.toString()) : null,
-        totalAmount: Number(createdOrder.totalAmount.toString()),
+        eventDate,
+        eventLocation,
         tickets: createdOrder.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
-          unitPrice: Number(item.unitPrice.toString()),
-          lineTotal: Number(item.totalPrice.toString()),
+          price: `${item.totalPrice.toString()} ${createdOrder.currency}`,
         })),
+        totalAmount: `${createdOrder.totalAmount.toString()} ${createdOrder.currency}`,
+        buyerName,
+        vatRate: parseFloat(createdOrder.vatRate.toString()),
+        vatAmount: createdOrder.vatAmount.toString(),
+        ticketCodes: createdOrder.tickets.map((t) => t.ticketCode),
       })
+
+      await sendAttendeeTicketEmailsForOrder({
+        orderNumber: createdOrder.orderNumber,
+        buyerEmail: createdOrder.buyerEmail,
+        buyerName,
+        eventTitle: createdOrder.event.title,
+        eventDate,
+        eventLocation,
+        tickets: createdOrder.tickets,
+        items: createdOrder.items,
+      })
+    } else {
+      // Notify organizer of the new invoice order
+      const organizerEmail = event.organizer.user.email
+      if (organizerEmail) {
+        const discountLabel = createdOrder.groupDiscount
+          ? `group ${createdOrder.groupDiscount.minQuantity}+, ${
+              createdOrder.groupDiscount.discountType === 'PERCENTAGE'
+                ? `${Number(createdOrder.groupDiscount.discountValue.toString())}%`
+                : `${Number(createdOrder.groupDiscount.discountValue.toString())} ${createdOrder.currency}`
+            } off`
+          : createdOrder.discountCode
+            ? `code ${createdOrder.discountCode.code}`
+            : null
+        await sendInvoiceOrderNotificationEmail(organizerEmail, {
+          orderNumber: createdOrder.orderNumber,
+          eventTitle: createdOrder.event.title,
+          eventId: createdOrder.event.id,
+          buyerName: `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`,
+          buyerEmail: createdOrder.buyerEmail,
+          currency: createdOrder.currency,
+          subtotal: Number(createdOrder.subtotal.toString()),
+          discountAmount: Number(createdOrder.discountAmount.toString()),
+          discountLabel,
+          vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
+          vatAmount: createdOrder.vatAmount ? Number(createdOrder.vatAmount.toString()) : null,
+          totalAmount: Number(createdOrder.totalAmount.toString()),
+          tickets: createdOrder.items.map((item) => ({
+            name: item.ticketType.name,
+            quantity: item.quantity,
+            unitPrice: Number(item.unitPrice.toString()),
+            lineTotal: Number(item.totalPrice.toString()),
+          })),
+        })
+      }
     }
 
     return NextResponse.json({

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -430,10 +430,16 @@ export async function POST(request: NextRequest) {
         let status: 'PENDING' | 'PENDING_INVOICE' | 'PAID' = 'PENDING'
         let paymentMethod: 'PAYPAL' | 'INVOICE' | 'FREE' = 'PAYPAL'
 
-        if (discountCodeRecord?.discountType === 'INVOICE') {
+        // A zero-total order is never invoiced — even when the applied discount
+        // code is INVOICE-typed (e.g. an INVOICE code used on a free ticket
+        // type, or stacked with a 100% group discount).
+        if (totalAmount === 0) {
+          status = 'PAID'
+          paymentMethod = 'FREE'
+        } else if (discountCodeRecord?.discountType === 'INVOICE') {
           status = 'PAID'
           paymentMethod = 'INVOICE'
-        } else if (totalAmount === 0 || discountCodeRecord?.discountType === 'FREE_TICKET') {
+        } else if (discountCodeRecord?.discountType === 'FREE_TICKET') {
           status = 'PAID'
           paymentMethod = 'FREE'
         }


### PR DESCRIPTION
## Summary
- Order creation checked `discountType === 'INVOICE'` before checking whether `totalAmount === 0`, so INVOICE-typed codes applied to free ticket types — or stacked with a 100% group discount — produced orders with `paymentMethod=INVOICE` even though the buyer owed nothing. Now `totalAmount === 0` always wins → `FREE` / `PAID`.
- The manual-order route hardcoded every order to `PENDING_INVOICE` / `INVOICE` regardless of total. Free manual orders now complete in place: `FREE` / `PAID`, `soldCount` incremented, tickets minted, buyer confirmation + per-attendee ticket emails sent (matching the public free-order path).
- Adds `scripts/backfill-free-orders-payment-method.ts` (dry-run by default) to flip historical zero-total orders that were misclassified as `INVOICE`. Already applied to prod (2 orders flipped) — script is included for posterity / dev parity.

Rule encoded in code: **we never invoice anyone for a free order.**

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 80/80 pass
- [ ] Smoke: place a public-checkout order with an INVOICE-typed discount code on a free ticket type → resulting order has `paymentMethod=FREE`, `status=PAID`, tickets minted, buyer + attendees emailed.
- [ ] Smoke: place a public-checkout order where an INVOICE code stacks with a 100% group discount → same as above.
- [ ] Smoke: dashboard manual order with a 100% group discount → `paymentMethod=FREE`, tickets minted, buyer + attendees emailed; no organizer "invoice notification" email sent.
- [ ] Smoke: dashboard manual order at full price → still `PENDING_INVOICE` / `INVOICE`, organizer notified as before.