### PR TITLE
feat(payments): enable Stripe Tax on Checkout Sessions

### DIFF
--- a/src/lib/payments/stripe.ts
+++ b/src/lib/payments/stripe.ts
@@ -100,17 +100,23 @@ export async function createStripeCheckoutSession(
   const currency = options.currency.toLowerCase()
   const configuredProductId = process.env.STRIPE_PRODUCT_ID
 
+  // `unit_amount` is the gross (VAT-inclusive) total — see prepareOrderItems in
+  // src/lib/orders/index.ts. Stripe Tax must therefore treat the price as
+  // tax-inclusive and back-calculate the VAT portion from the buyer's location.
   const priceData: Stripe.Checkout.SessionCreateParams.LineItem.PriceData = configuredProductId
     ? {
         currency,
         unit_amount: amountMinor,
+        tax_behavior: 'inclusive',
         product: configuredProductId,
       }
     : {
         currency,
         unit_amount: amountMinor,
+        tax_behavior: 'inclusive',
         product_data: {
           name: options.description || `OpenEvents Order ${options.orderId}`,
+          tax_code: 'txcd_10000000',
         },
       }
 
@@ -124,6 +130,9 @@ export async function createStripeCheckoutSession(
         price_data: priceData,
       },
     ],
+    automatic_tax: { enabled: true },
+    billing_address_collection: 'required',
+    tax_id_collection: { enabled: true },
     metadata: {
       orderId: options.orderId,
     },


### PR DESCRIPTION
## Summary

Fixes #361. Enables Stripe Tax (`automatic_tax`) on every Checkout Session so VAT is calculated per transaction and shows up in Stripe Tax reports.

Changes in `src/lib/payments/stripe.ts`:

- `automatic_tax: { enabled: true }` on every session.
- `billing_address_collection: 'required'` so Stripe knows the buyer's country.
- `tax_id_collection: { enabled: true }` so EU B2B buyers can enter a VAT-ID and get reverse charge (0% VAT).
- `tax_behavior: 'inclusive'` on the inline price. The `unit_amount` we send to Stripe is the order's `totalAmount`, which is already gross (see `prepareOrderItems` in `src/lib/orders/index.ts:85`), so Stripe must back-calculate the VAT portion rather than add it on top — otherwise we would double-charge VAT.
- `tax_code: 'txcd_10000000'` (general services) on the inline `product_data` fallback. For the configured `STRIPE_PRODUCT_ID` path, the tax_code lives on the Product in the Stripe dashboard (per the issue, "verify, not code").

`customer_update: { address: 'auto' }` is intentionally not set because no `customer` is passed to `sessions.create`.

## Stripe Dashboard checklist (out of code)

- [ ] Stripe Tax enabled.
- [ ] Tax registration for Sweden (SE) active at 25% standard rate.
- [ ] Product behind `STRIPE_PRODUCT_ID` has a `tax_code` set (e.g. `txcd_10000000`).

## Test plan

In Stripe **test mode**:

- [ ] Test purchase from a Swedish address — verify 25% VAT applied on the line item.
- [ ] Test purchase from a UK / DE address as a private buyer — verify destination VAT applied.
- [ ] Test purchase as an EU business with a valid VAT-ID — verify reverse charge (0% VAT).
- [ ] Test purchase from a non-EU country (US) — verify no Swedish VAT.
- [ ] Verify capture and refund flows still work unchanged.
- [ ] Confirm transactions appear in the Stripe Tax dashboard with country + tax breakdown.