### PR TITLE
Resolved issues (#313, #339, #347, #348)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,7 +1263,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1649,7 +1648,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1698,7 +1696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2395,7 +2392,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
@@ -3226,7 +3222,6 @@
       "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -5440,6 +5435,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5460,6 +5456,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5473,6 +5470,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5483,6 +5481,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5497,7 +5496,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -5559,7 +5559,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.4.tgz",
       "integrity": "sha512-3i/DG89TFY/b34T5P+j35UcjYuB5d3+9K8u6qID+iUqNPiza015HPIZLuPfE5elNwVdV3EXIoPo0LLeBLgXXAg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5782,7 +5781,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.4.tgz",
       "integrity": "sha512-X+5plTKhOioNcQ4KsAFJJSb/3+zR8Xhdpow4HzXtoV1KcbdDey1fhZdpsfkbrzCL0s6/wAgwZuAchCK7HujurQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5901,7 +5899,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.4.tgz",
       "integrity": "sha512-8p6hVT65DjuQjtEdlH6ewX9SOJHlVQAOee3sWIJQmeJNRnZNvqPIBLleebUqDiljNTpxBv6s6QWkSTKgf3btwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5916,7 +5913,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.4.tgz",
       "integrity": "sha512-rCHYSBToilBEuI6PtjziHDdRkABH/XqwJ7dG4Amn/SD3yGiZKYCiEApQlTUS2zZeo8DsLeuqqqB4vEOeD4OEPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -6049,7 +6045,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6179,7 +6176,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6217,7 +6213,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6227,7 +6222,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6299,7 +6293,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -6944,7 +6937,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7516,7 +7508,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8231,6 +8222,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8298,7 +8290,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8765,7 +8758,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8951,7 +8943,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11325,6 +11316,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11681,7 +11673,6 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
       "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12233,7 +12224,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12274,7 +12264,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -12424,7 +12413,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -12454,7 +12442,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -12503,7 +12490,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -12609,7 +12595,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12619,7 +12604,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12646,7 +12630,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -13774,8 +13757,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13871,7 +13853,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14152,7 +14133,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14466,7 +14446,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14560,7 +14539,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15050,7 +15028,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/prisma/migrations/20260428120000_add_invoice_number_sequence/migration.sql
+++ b/prisma/migrations/20260428120000_add_invoice_number_sequence/migration.sql
@@ -1,0 +1,8 @@
+-- CreateSequence
+CREATE SEQUENCE IF NOT EXISTS "invoice_number_seq" START WITH 1 INCREMENT BY 1 NO CYCLE;
+
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN "invoiceNumber" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orders_invoiceNumber_key" ON "orders"("invoiceNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -435,6 +435,7 @@ model GroupDiscount {
 model Order {
   id              String       @id @default(cuid())
   orderNumber     String       @unique
+  invoiceNumber   Int?         @unique  // Sequential invoice number for INVOICE payment method orders (Swedish VAT compliance)
   userId          String?
   eventId         String
   discountCodeId  String?

--- a/src/app/api/dashboard/events/[id]/orders/export/route.ts
+++ b/src/app/api/dashboard/events/[id]/orders/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { OrderStatus, PaymentMethod, Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { requireOrganizerProfile } from '@/lib/dashboard/organizer'
+import { ORDER_STATUS_LABELS, PAYMENT_METHOD_LABELS } from '@/lib/labels'
 
 type RouteContext = {
   params: Promise<{ id: string }>
@@ -79,8 +80,8 @@ export async function GET(request: Request, context: RouteContext) {
         csvCell(order.orderNumber),
         csvCell(`${order.buyerFirstName} ${order.buyerLastName}`.trim()),
         csvCell(order.buyerEmail),
-        csvCell(order.status),
-        csvCell(order.paymentMethod),
+        csvCell(ORDER_STATUS_LABELS[order.status]),
+        csvCell(order.paymentMethod ? PAYMENT_METHOD_LABELS[order.paymentMethod] : null),
         csvCell(order.subtotal.toString()),
         csvCell(order.discountAmount.toString()),
         csvCell(order.totalAmount.toString()),

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -334,9 +334,19 @@ export async function POST(request: NextRequest) {
         const orderStatus = isFreeOrder ? 'PAID' : 'PENDING_INVOICE'
         const orderPaymentMethod = isFreeOrder ? 'FREE' : 'INVOICE'
 
+        // Assign a sequential invoice number for all non-free invoice orders.
+        // We call nextval inside the transaction so the number is only consumed
+        // when the order actually commits (avoiding gaps from rolled-back orders).
+        let invoiceNumber: number | null = null
+        if (!isFreeOrder) {
+          const seqResult = await tx.$queryRaw<[{ nextval: bigint }]>`SELECT nextval('invoice_number_seq')`
+          invoiceNumber = Number(seqResult[0].nextval)
+        }
+
         const order = await tx.order.create({
           data: {
             orderNumber: generateOrderNumber(),
+            invoiceNumber: invoiceNumber ?? undefined,
             userId: null, // Manual orders don't have a user association
             eventId: input.eventId,
             discountCodeId: appliedDiscountCodeId,

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -444,6 +444,13 @@ export async function POST(request: NextRequest) {
           paymentMethod = 'FREE'
         }
 
+        // Assign a sequential invoice number for INVOICE payment method orders.
+        let invoiceNumber: number | null = null
+        if (paymentMethod === 'INVOICE') {
+          const seqResult = await tx.$queryRaw<[{ nextval: bigint }]>`SELECT nextval('invoice_number_seq')`
+          invoiceNumber = Number(seqResult[0].nextval)
+        }
+
         const now = new Date()
         // PENDING orders no longer auto-expire; organizers manage them manually
         // via the dashboard (reminder flow + manual cancel).
@@ -452,6 +459,7 @@ export async function POST(request: NextRequest) {
         const order = await tx.order.create({
           data: {
             orderNumber: generateOrderNumber(),
+            invoiceNumber: invoiceNumber ?? undefined,
             userId: user?.id, // Associate with user if logged in
             eventId: input.eventId,
             discountCodeId: appliedDiscountCodeId,

--- a/src/app/api/tickets/verify/[code]/route.ts
+++ b/src/app/api/tickets/verify/[code]/route.ts
@@ -8,110 +8,120 @@ type RouteParams = {
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
-  const session = await getServerSession(authOptions)
+  try {
+    const session = await getServerSession(authOptions)
 
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const hasOrganizerRole = session.user.roles?.includes('ORGANIZER') || session.user.roles?.includes('SUPER_ADMIN')
+    if (!hasOrganizerRole) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { code } = await params
+
+    const ticket = await prisma.ticket.findUnique({
+      where: { ticketCode: code },
+      select: {
+        id: true,
+        status: true,
+      },
+    })
+
+    if (!ticket) {
+      return NextResponse.json({ valid: false, error: 'Ticket not found' }, { status: 404 })
+    }
+
+    // Return minimal fields only - no PII
+    return NextResponse.json({
+      valid: ticket.status === 'ACTIVE',
+      ticketId: ticket.id,
+      status: ticket.status,
+    })
+  } catch (error) {
+    console.error('Failed to verify ticket:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
-
-  const hasOrganizerRole = session.user.roles?.includes('ORGANIZER') || session.user.roles?.includes('SUPER_ADMIN')
-  if (!hasOrganizerRole) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  const { code } = await params
-
-  const ticket = await prisma.ticket.findUnique({
-    where: { ticketCode: code },
-    select: {
-      id: true,
-      status: true,
-    },
-  })
-
-  if (!ticket) {
-    return NextResponse.json({ valid: false, error: 'Ticket not found' }, { status: 404 })
-  }
-
-  // Return minimal fields only - no PII
-  return NextResponse.json({
-    valid: ticket.status === 'ACTIVE',
-    ticketId: ticket.id,
-    status: ticket.status,
-  })
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  const session = await getServerSession(authOptions)
+  try {
+    const session = await getServerSession(authOptions)
 
-  if (!session?.user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
-  const hasOrganizerRole = session.user.roles?.includes('ORGANIZER') || session.user.roles?.includes('SUPER_ADMIN')
-  if (!hasOrganizerRole) {
-    return NextResponse.json({ error: 'Not authorized to check in tickets' }, { status: 403 })
-  }
+    const hasOrganizerRole = session.user.roles?.includes('ORGANIZER') || session.user.roles?.includes('SUPER_ADMIN')
+    if (!hasOrganizerRole) {
+      return NextResponse.json({ error: 'Not authorized to check in tickets' }, { status: 403 })
+    }
 
-  const { code } = await params
+    const { code } = await params
 
-  const ticket = await prisma.ticket.findUnique({
-    where: { ticketCode: code },
-    include: {
-      order: {
-        include: {
-          event: {
-            select: {
-              id: true,
-              title: true,
+    const ticket = await prisma.ticket.findUnique({
+      where: { ticketCode: code },
+      include: {
+        order: {
+          include: {
+            event: {
+              select: {
+                id: true,
+                title: true,
+              },
             },
           },
         },
       },
-    },
-  })
+    })
 
-  if (!ticket) {
-    return NextResponse.json({ valid: false, error: 'Ticket not found' }, { status: 404 })
-  }
+    if (!ticket) {
+      return NextResponse.json({ valid: false, error: 'Ticket not found' }, { status: 404 })
+    }
 
-  if (ticket.status === 'USED') {
-    return NextResponse.json(
-      {
-        valid: false,
-        error: 'Already checked in',
-        attendee: ticket.attendeeFirstName
-          ? `${ticket.attendeeFirstName} ${ticket.attendeeLastName}`
-          : null,
-        checkedInAt: ticket.checkedInAt,
+    if (ticket.status === 'USED') {
+      return NextResponse.json(
+        {
+          valid: false,
+          error: 'Already checked in',
+          attendee: ticket.attendeeFirstName
+            ? `${ticket.attendeeFirstName} ${ticket.attendeeLastName}`
+            : null,
+          checkedInAt: ticket.checkedInAt,
+        },
+        { status: 400 }
+      )
+    }
+
+    if (ticket.status === 'CANCELLED') {
+      return NextResponse.json(
+        { valid: false, error: 'Ticket has been cancelled' },
+        { status: 400 }
+      )
+    }
+
+    // Mark ticket as used
+    const updatedTicket = await prisma.ticket.update({
+      where: { id: ticket.id },
+      data: {
+        status: 'USED',
+        checkedInAt: new Date(),
       },
-      { status: 400 }
-    )
+    })
+
+    return NextResponse.json({
+      valid: true,
+      ticketCode: updatedTicket.ticketCode,
+      attendee: updatedTicket.attendeeFirstName
+        ? `${updatedTicket.attendeeFirstName} ${updatedTicket.attendeeLastName}`
+        : null,
+      event: ticket.order.event.title,
+      checkedInAt: updatedTicket.checkedInAt,
+    })
+  } catch (error) {
+    console.error('Failed to check in ticket:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
-
-  if (ticket.status === 'CANCELLED') {
-    return NextResponse.json(
-      { valid: false, error: 'Ticket has been cancelled' },
-      { status: 400 }
-    )
-  }
-
-  // Mark ticket as used
-  const updatedTicket = await prisma.ticket.update({
-    where: { id: ticket.id },
-    data: {
-      status: 'USED',
-      checkedInAt: new Date(),
-    },
-  })
-
-  return NextResponse.json({
-    valid: true,
-    ticketCode: updatedTicket.ticketCode,
-    attendee: updatedTicket.attendeeFirstName
-      ? `${updatedTicket.attendeeFirstName} ${updatedTicket.attendeeLastName}`
-      : null,
-    event: ticket.order.event.title,
-    checkedInAt: updatedTicket.checkedInAt,
-  })
 }

--- a/src/components/dashboard/OrderDetailView.tsx
+++ b/src/components/dashboard/OrderDetailView.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
+import { ORDER_STATUS_LABELS } from '@/lib/labels'
+import { OrderStatus } from '@prisma/client'
 import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
 import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 import { useToast } from '@/components/ui/toaster'
@@ -75,7 +77,7 @@ export function OrderDetailView({ order, refundAction, emailAction, markPaidActi
       <section className="rounded-xl border border-gray-200 bg-white p-6">
         <h1 className="text-2xl font-bold text-gray-900">Order {order.orderNumber}</h1>
         <p className="mt-1 text-sm text-gray-600">
-          {order.status} · {formatPaymentMethodLabel(order.paymentMethod, 'No payment method')} · {formatDateTime(order.createdAt)}
+          {ORDER_STATUS_LABELS[order.status as OrderStatus] ?? order.status} · {formatPaymentMethodLabel(order.paymentMethod, 'No payment method')} · {formatDateTime(order.createdAt)}
         </p>
         {order.paymentMethod === 'INVOICE' && (
           <p className="mt-2 inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">

--- a/src/components/dashboard/OrderDetails.tsx
+++ b/src/components/dashboard/OrderDetails.tsx
@@ -1,5 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
+import { ORDER_STATUS_LABELS } from '@/lib/labels'
+import { OrderStatus } from '@prisma/client'
 
 export interface DashboardOrderDetails {
   id: string
@@ -35,7 +37,7 @@ export function OrderDetails({ order }: OrderDetailsProps) {
       <CardContent className="space-y-3 text-sm">
         <div className="grid gap-2 sm:grid-cols-2">
           <p>
-            <span className="font-medium text-gray-900">Status:</span> {order.status}
+            <span className="font-medium text-gray-900">Status:</span> {ORDER_STATUS_LABELS[order.status as OrderStatus] ?? order.status}
           </p>
           <p>
             <span className="font-medium text-gray-900">Payment:</span>{' '}

--- a/src/components/dashboard/OrderFilters.tsx
+++ b/src/components/dashboard/OrderFilters.tsx
@@ -1,4 +1,5 @@
 import { OrderStatus, PaymentMethod } from '@prisma/client'
+import { ORDER_STATUS_LABELS, PAYMENT_METHOD_LABELS } from '@/lib/labels'
 
 type OrderFiltersProps = {
   initial: {
@@ -26,21 +27,18 @@ export function OrderFilters({ initial }: OrderFiltersProps) {
         <label htmlFor="status" className="text-xs font-medium text-gray-600">Status</label>
         <select id="status" name="status" defaultValue={initial.status || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm">
           <option value="">All</option>
-          <option value="PENDING">PENDING</option>
-          <option value="PENDING_INVOICE">PENDING_INVOICE</option>
-          <option value="PAID">PAID</option>
-          <option value="CANCELLED">CANCELLED</option>
-          <option value="REFUNDED">REFUNDED</option>
-          <option value="PARTIALLY_REFUNDED">PARTIALLY_REFUNDED</option>
+          {(Object.keys(ORDER_STATUS_LABELS) as OrderStatus[]).map((status) => (
+            <option key={status} value={status}>{ORDER_STATUS_LABELS[status]}</option>
+          ))}
         </select>
       </div>
       <div>
         <label htmlFor="paymentMethod" className="text-xs font-medium text-gray-600">Payment</label>
         <select id="paymentMethod" name="paymentMethod" defaultValue={initial.paymentMethod || ''} className="mt-1 h-10 w-full rounded-md border border-gray-300 px-3 text-sm">
           <option value="">All</option>
-          <option value="PAYPAL">Stripe</option>
-          <option value="INVOICE">Invoice</option>
-          <option value="FREE">Free</option>
+          {(Object.keys(PAYMENT_METHOD_LABELS) as PaymentMethod[]).map((method) => (
+            <option key={method} value={method}>{PAYMENT_METHOD_LABELS[method]}</option>
+          ))}
         </select>
       </div>
       <div>

--- a/src/components/dashboard/OrderList.tsx
+++ b/src/components/dashboard/OrderList.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { type DashboardOrderDetails } from '@/components/dashboard/OrderDetails'
 import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
+import { ORDER_STATUS_LABELS } from '@/lib/labels'
+import { OrderStatus } from '@prisma/client'
 
 export interface DashboardOrderListItem extends DashboardOrderDetails {
   event: {
@@ -111,7 +113,7 @@ export function OrderList({ orders }: OrderListProps) {
               <CardContent className="space-y-3 text-sm text-gray-700">
                 <div className="grid gap-2 sm:grid-cols-2">
                   <p>
-                    <span className="font-medium text-gray-900">Status:</span> {order.status}
+                    <span className="font-medium text-gray-900">Status:</span> {ORDER_STATUS_LABELS[order.status as OrderStatus] ?? order.status}
                     {(() => {
                       const label = getPendingOrderLabel(order)
                       if (!label) return null

--- a/src/components/dashboard/OrdersTable.tsx
+++ b/src/components/dashboard/OrdersTable.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { OrderStatus, PaymentMethod, DiscountType } from '@prisma/client'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { formatPaymentMethodLabel } from '@/lib/payments/labels'
+import { ORDER_STATUS_LABELS } from '@/lib/labels'
 import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
 
 type OrdersTableProps = {
@@ -62,7 +63,7 @@ export function OrdersTable({ eventId, orders }: OrdersTableProps) {
                 </td>
                 <td className="px-4 py-3 text-gray-700">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span>{order.status}</span>
+                    <span>{ORDER_STATUS_LABELS[order.status]}</span>
                     {(() => {
                       const label = getPendingOrderLabel(order)
                       if (!label) return null

--- a/src/components/dashboard/RecentOrders.tsx
+++ b/src/components/dashboard/RecentOrders.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { OrderStatus, PaymentMethod } from '@prisma/client'
 import { formatCurrency, formatDateTime } from '@/lib/utils'
 import { getPendingOrderLabel } from '@/lib/orders/pendingLabel'
+import { ORDER_STATUS_LABELS } from '@/lib/labels'
 
 type RecentOrdersProps = {
   orders: Array<{
@@ -45,7 +46,7 @@ export function RecentOrders({ orders }: RecentOrdersProps) {
                 </div>
                 <p className="text-sm text-gray-600">{order.event.title}</p>
                 <p className="text-xs text-gray-500">
-                  {order.buyerEmail} · {order.status}
+                  {order.buyerEmail} · {ORDER_STATUS_LABELS[order.status]}
                   {pendingLabel && (
                     <span
                       className={`ml-1 inline-flex items-center justify-center rounded-full px-2 py-0.5 text-center text-xs font-medium ${

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { buyerInfoSchema, checkoutAttendeeSchema } from '@/lib/validations/order'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
@@ -269,6 +270,11 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [countryError, setCountryError] = useState<string | null>(null)
   const [isRedirecting, setIsRedirecting] = useState(false)
+  const [buyerFieldErrors, setBuyerFieldErrors] = useState<Partial<Record<keyof BuyerFormState, string>>>({})
+  const [touchedBuyerFields, setTouchedBuyerFields] = useState<Set<keyof BuyerFormState>>(new Set())
+  const [attendeeFieldErrors, setAttendeeFieldErrors] = useState<Record<string, string | undefined>>({})
+  const [touchedAttendeeFields, setTouchedAttendeeFields] = useState<Set<string>>(new Set())
+  const [hasSubmitted, setHasSubmitted] = useState(false)
   const [reservationTtlMinutes, setReservationTtlMinutes] = useState(initialReservationTtlMinutes)
   const [reservationExpiresAt, setReservationExpiresAt] = useState<Date | null>(() =>
     new Date(Date.now() + initialReservationTtlMinutes * 60 * 1000)
@@ -634,12 +640,44 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
       ...current,
       [field]: value,
     }))
+    if (touchedBuyerFields.has(field) || hasSubmitted) {
+      const error = validateSingleBuyerField(field, value as string)
+      setBuyerFieldErrors((prev) => ({ ...prev, [field]: error ?? undefined }))
+    }
   }
 
   function validateCountry(value: string): string | null {
     if (!value.trim()) return null
     const isValid = COUNTRIES.some((c) => c.name.toLowerCase() === value.trim().toLowerCase())
     return isValid ? null : 'Please write a valid country.'
+  }
+
+  function validateSingleBuyerField(field: keyof BuyerFormState, value: string): string | null {
+    const fieldSchema = buyerInfoSchema.shape[field as keyof typeof buyerInfoSchema.shape]
+    if (!fieldSchema) return null
+    const result = fieldSchema.safeParse(value)
+    return result.success ? null : result.error.issues[0]?.message ?? null
+  }
+
+  function validateSingleAttendeeField(field: keyof AttendeeFormState, value: string): string | null {
+    const shape = checkoutAttendeeSchema.shape
+    const fieldSchema = shape[field as keyof typeof shape]
+    if (!fieldSchema) return null
+    const result = fieldSchema.safeParse(value)
+    return result.success ? null : result.error.issues[0]?.message ?? null
+  }
+
+  function handleBuyerBlur(field: keyof BuyerFormState, value: string) {
+    setTouchedBuyerFields((prev) => new Set(prev).add(field))
+    const error = validateSingleBuyerField(field, value)
+    setBuyerFieldErrors((prev) => ({ ...prev, [field]: error ?? undefined }))
+  }
+
+  function handleAttendeeBlur(ticketTypeId: string, index: number, field: keyof AttendeeFormState, value: string) {
+    const key = `${ticketTypeId}:${index}:${field}`
+    setTouchedAttendeeFields((prev) => new Set(prev).add(key))
+    const error = validateSingleAttendeeField(field, value)
+    setAttendeeFieldErrors((prev) => ({ ...prev, [key]: error ?? undefined }))
   }
 
   function updateAttendeeField(
@@ -654,6 +692,11 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
       slots[index] = { ...slots[index], [field]: value }
       return { ...current, [ticketTypeId]: slots }
     })
+    const key = `${ticketTypeId}:${index}:${field}`
+    if (touchedAttendeeFields.has(key) || hasSubmitted) {
+      const error = validateSingleAttendeeField(field, value)
+      setAttendeeFieldErrors((prev) => ({ ...prev, [key]: error ?? undefined }))
+    }
   }
 
   function fillAttendeeFromBuyer(ticketTypeId: string, index: number) {
@@ -685,36 +728,38 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
       return
     }
 
-    const buyerEmailValue = buyer.email.trim()
+    setHasSubmitted(true)
 
-    if (!buyer.firstName || !buyer.lastName) {
-      setSubmitError('First name and last name are required')
-      return
+    // Validate all buyer fields using the server-side Zod schema
+    const newBuyerErrors: Partial<Record<keyof BuyerFormState, string>> = {}
+    for (const field of Object.keys(buyerInfoSchema.shape) as (keyof BuyerFormState)[]) {
+      const error = validateSingleBuyerField(field, buyer[field])
+      if (error) newBuyerErrors[field] = error
     }
-
-    if (!buyerEmailValue) {
-      setSubmitError('Email address is required')
-      return
-    }
+    setBuyerFieldErrors(newBuyerErrors)
 
     const countryValidationError = validateCountry(buyer.country)
-    if (countryValidationError) {
-      setCountryError(countryValidationError)
-      return
-    }
+    if (countryValidationError) setCountryError(countryValidationError)
 
-    // Validate all attendee slots are filled
+    // Validate all attendee fields
+    const newAttendeeErrors: Record<string, string> = {}
     for (const item of selectedItems) {
       const slots = attendeesByType[item.ticketTypeId] ?? []
       for (let i = 0; i < item.quantity; i++) {
-        const a = slots[i]
-        if (!a || !a.firstName || !a.lastName || !a.email) {
-          const ticketName = displayTicketTypes.find((t) => t.id === item.ticketTypeId)?.name ?? 'ticket'
-          setSubmitError(`Please fill in all attendee details for "${ticketName}" (ticket ${i + 1})`)
-          return
+        const a = slots[i] ?? emptyAttendee()
+        for (const field of (['firstName', 'lastName', 'email', 'organization'] as (keyof AttendeeFormState)[])) {
+          const error = validateSingleAttendeeField(field, a[field])
+          if (error) newAttendeeErrors[`${item.ticketTypeId}:${i}:${field}`] = error
         }
       }
     }
+    setAttendeeFieldErrors(newAttendeeErrors)
+
+    if (Object.keys(newBuyerErrors).length > 0 || countryValidationError || Object.keys(newAttendeeErrors).length > 0) {
+      return
+    }
+
+    const buyerEmailValue = buyer.email.trim()
 
     setIsSubmitting(true)
     setSubmitError(null)
@@ -852,7 +897,7 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
   }
 
   return (
-    <form className="grid gap-6 lg:grid-cols-3" onSubmit={handleSubmit}>
+    <form className="grid gap-6 lg:grid-cols-3" onSubmit={handleSubmit} noValidate>
       <div className="space-y-6 lg:col-span-2">
         <Card>
           <CardHeader>
@@ -889,6 +934,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                 id="buyer-first-name"
                 value={buyer.firstName}
                 onChange={(eventValue) => updateBuyerField('firstName', eventValue.target.value)}
+                onBlur={(e) => handleBuyerBlur('firstName', e.target.value)}
+                error={buyerFieldErrors.firstName}
                 required
               />
             </div>
@@ -900,6 +947,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                 id="buyer-last-name"
                 value={buyer.lastName}
                 onChange={(eventValue) => updateBuyerField('lastName', eventValue.target.value)}
+                onBlur={(e) => handleBuyerBlur('lastName', e.target.value)}
+                error={buyerFieldErrors.lastName}
                 required
               />
             </div>
@@ -912,6 +961,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                 type="email"
                 value={buyer.email}
                 onChange={(eventValue) => updateBuyerField('email', eventValue.target.value)}
+                onBlur={(e) => handleBuyerBlur('email', e.target.value)}
+                error={buyerFieldErrors.email}
                 required
               />
             </div>
@@ -929,6 +980,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                 id="buyer-organization"
                 value={buyer.organization}
                 onChange={(eventValue) => updateBuyerField('organization', eventValue.target.value)}
+                onBlur={(e) => handleBuyerBlur('organization', e.target.value)}
+                error={buyerFieldErrors.organization}
                 required
               />
             </div>
@@ -1028,6 +1081,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 onChange={(e) =>
                                   updateAttendeeField(item.ticketTypeId, i, 'firstName', e.target.value)
                                 }
+                                onBlur={(e) => handleAttendeeBlur(item.ticketTypeId, i, 'firstName', e.target.value)}
+                                error={attendeeFieldErrors[`${item.ticketTypeId}:${i}:firstName`]}
                                 required
                               />
                             </div>
@@ -1044,6 +1099,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 onChange={(e) =>
                                   updateAttendeeField(item.ticketTypeId, i, 'lastName', e.target.value)
                                 }
+                                onBlur={(e) => handleAttendeeBlur(item.ticketTypeId, i, 'lastName', e.target.value)}
+                                error={attendeeFieldErrors[`${item.ticketTypeId}:${i}:lastName`]}
                                 required
                               />
                             </div>
@@ -1061,6 +1118,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 onChange={(e) =>
                                   updateAttendeeField(item.ticketTypeId, i, 'email', e.target.value)
                                 }
+                                onBlur={(e) => handleAttendeeBlur(item.ticketTypeId, i, 'email', e.target.value)}
+                                error={attendeeFieldErrors[`${item.ticketTypeId}:${i}:email`]}
                                 required
                               />
                             </div>
@@ -1086,6 +1145,8 @@ export function CheckoutForm({ event, groupDiscounts = [] }: CheckoutFormProps) 
                                 onChange={(e) =>
                                   updateAttendeeField(item.ticketTypeId, i, 'organization', e.target.value)
                                 }
+                                onBlur={(e) => handleAttendeeBlur(item.ticketTypeId, i, 'organization', e.target.value)}
+                                error={attendeeFieldErrors[`${item.ticketTypeId}:${i}:organization`]}
                                 required
                               />
                             </div>

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,0 +1,16 @@
+import { OrderStatus, PaymentMethod } from '@prisma/client'
+
+export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  PENDING: 'Pending',
+  PENDING_INVOICE: 'Pending Invoice',
+  PAID: 'Paid',
+  CANCELLED: 'Cancelled',
+  REFUNDED: 'Refunded',
+  PARTIALLY_REFUNDED: 'Partially Refunded',
+}
+
+export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  PAYPAL: 'Stripe',
+  INVOICE: 'Invoice',
+  FREE: 'Free',
+}

--- a/src/lib/pdf/buildReceiptData.ts
+++ b/src/lib/pdf/buildReceiptData.ts
@@ -100,6 +100,9 @@ export async function buildReceiptDataForOrder(
 
   return {
     orderNumber: order.orderNumber,
+    invoiceNumber: order.invoiceNumber != null
+      ? `INV-${String(order.invoiceNumber).padStart(4, '0')}`
+      : null,
     orderDate: order.createdAt,
     paidAt: order.paidAt,
     status: order.status,

--- a/src/lib/pdf/receipt.ts
+++ b/src/lib/pdf/receipt.ts
@@ -4,6 +4,7 @@ import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
 
 export interface ReceiptData {
   orderNumber: string
+  invoiceNumber: string | null  // Formatted sequential invoice number (e.g. "INV-0001"), null for non-invoice orders
   orderDate: Date
   paidAt: Date | null
   status: string
@@ -112,7 +113,8 @@ export function generateReceiptPdf(data: ReceiptData): Promise<Buffer> {
     const colWidth = pageRight - pageLeft
 
     // ---- Header ----
-    doc.fontSize(26).font('Helvetica-Bold').text('RECEIPT', pageLeft, 50)
+    const isInvoice = data.invoiceNumber != null
+    doc.fontSize(26).font('Helvetica-Bold').text(isInvoice ? 'INVOICE' : 'RECEIPT', pageLeft, 50)
 
     // Issuer block (legal entity issuing the receipt, from the event organizer)
     doc.fontSize(10).font('Helvetica-Bold').fillColor('#000').text(data.seller.name, pageLeft, 82)
@@ -131,28 +133,41 @@ export function generateReceiptPdf(data: ReceiptData): Promise<Buffer> {
     }
     doc.fillColor('#000')
 
-    // Right side: receipt metadata box
+    // Right side: receipt/invoice metadata box
     const metaX = 360
     let metaY = 50
-    doc.fontSize(10).font('Helvetica-Bold').text('Receipt #', metaX, metaY)
-    doc.font('Helvetica').text(data.orderNumber, metaX + 80, metaY)
+    // Value column starts 60pt after the label column, giving 125pt of space
+    // (pageRight 545 − value start 420). This ensures the order number
+    // "OE-XXXXXXXX-XXXX" (≈107pt) never wraps onto the next label row.
+    const metaValX = metaX + 60
+    const metaValueOpts = { lineBreak: false, width: pageRight - metaValX }
+    if (isInvoice) {
+      doc.fontSize(10).font('Helvetica-Bold').text('Invoice #', metaX, metaY)
+      doc.font('Helvetica').text(data.invoiceNumber!, metaValX, metaY, metaValueOpts)
+      metaY += 14
+      doc.font('Helvetica-Bold').text('Receipt #', metaX, metaY)
+      doc.font('Helvetica').text(data.orderNumber, metaValX, metaY, metaValueOpts)
+    } else {
+      doc.fontSize(10).font('Helvetica-Bold').text('Receipt #', metaX, metaY)
+      doc.font('Helvetica').text(data.orderNumber, metaValX, metaY, metaValueOpts)
+    }
     metaY += 14
     doc.font('Helvetica-Bold').text('Issued', metaX, metaY)
-    doc.font('Helvetica').text(formatDate(new Date()), metaX + 80, metaY)
+    doc.font('Helvetica').text(formatDate(new Date()), metaValX, metaY, metaValueOpts)
     metaY += 14
     doc.font('Helvetica-Bold').text('Order date', metaX, metaY)
-    doc.font('Helvetica').text(formatDate(data.orderDate), metaX + 80, metaY)
+    doc.font('Helvetica').text(formatDate(data.orderDate), metaValX, metaY, metaValueOpts)
     if (data.paidAt) {
       metaY += 14
       doc.font('Helvetica-Bold').text('Paid on', metaX, metaY)
-      doc.font('Helvetica').text(formatDate(data.paidAt), metaX + 80, metaY)
+      doc.font('Helvetica').text(formatDate(data.paidAt), metaValX, metaY, metaValueOpts)
     }
     metaY += 14
     doc.font('Helvetica-Bold').text('Status', metaX, metaY)
-    doc.font('Helvetica').text(humanStatus(data.status), metaX + 80, metaY)
+    doc.font('Helvetica').text(humanStatus(data.status), metaValX, metaY, metaValueOpts)
     metaY += 14
     doc.font('Helvetica-Bold').text('Payment', metaX, metaY)
-    doc.font('Helvetica').text(humanPaymentMethod(data.paymentMethod), metaX + 80, metaY)
+    doc.font('Helvetica').text(humanPaymentMethod(data.paymentMethod), metaValX, metaY, metaValueOpts)
 
     // Move cursor below both columns
     doc.y = Math.max(120, metaY + 30)
@@ -355,12 +370,10 @@ export function generateReceiptPdf(data: ReceiptData): Promise<Buffer> {
     const footerIssuer = data.seller.orgNumber
       ? `${data.seller.name} (Org.nr ${data.seller.orgNumber})`
       : data.seller.name
-    doc.text(
-      `Receipt for order #${data.orderNumber} issued by ${footerIssuer}.`,
-      pageLeft,
-      doc.y,
-      { width: colWidth, align: 'center' }
-    )
+    const footerRef = data.invoiceNumber
+      ? `Invoice ${data.invoiceNumber} (order #${data.orderNumber}) issued by ${footerIssuer}.`
+      : `Receipt for order #${data.orderNumber} issued by ${footerIssuer}.`
+    doc.text(footerRef, pageLeft, doc.y, { width: colWidth, align: 'center' })
     doc.text('Thank you for your purchase.', pageLeft, doc.y, {
       width: colWidth,
       align: 'center',


### PR DESCRIPTION
### Issue #313: VAT: Implement sequential invoice number series for Swedish tax compliance                                                                    
                                                                              
  Invoices generated for INVOICE-method orders did not meet Swedish VAT law (ML 11 kap. 8 §), which requires a sequential, unbroken invoice number
  series per seller. The existing order number (timestamp + random suffix)      does not qualify. This adds a dedicated invoiceNumber field backed by a
  PostgreSQL sequence, and updates the PDF to render as a proper invoice when
  one is present.

###   What changed

  - prisma/schema.prisma — Added invoiceNumber Int? @unique to the Order model  - prisma/migrations/.../migration.sql — Creates the invoice_number_seq DB sequence and adds the column with a unique index
  - src/app/api/orders/route.ts — Draws the next sequence value for INVOICE-method orders; zero-total and card orders are unaffected
  - src/app/api/orders/manual/route.ts — Same as above for dashboard manual orders
  - src/lib/pdf/buildReceiptData.ts — Formats invoiceNumber as INV-0001 and includes it in the PDF data; null for non-invoice orders
  - src/lib/pdf/receipt.ts — Invoice PDFs now show the title INVOICE, both invoice and receipt numbers in the metadata block, and an updated footer. Receipt PDFs (card/free orders) are unchanged.

  ### Test plan

- [x]   An INVOICE-method order gets a non-null invoiceNumber (e.g. 1)
- [x]   A second INVOICE order gets the next number in sequence (e.g. 2)
- [x]   A zero-total INVOICE order gets invoiceNumber = null and paymentMethod = FREE
- [x]   Invoice PDF title reads INVOICE and shows both Invoice # (INV-0001) and Receipt # (OE-…)
- [x]   Receipt PDF (card/free orders) is unchanged — title RECEIPT, only Receipt # shown

---

### Issue #348 — Raw enum values in organizer admin UI                                             
  Problem: Order status (PENDING_INVOICE, PARTIALLY_REFUNDED) and payment method (PAYPAL) were   displayed as raw Prisma enum strings throughout the admin UI and CSV export.             

  Fix: Created a central label map and applied it everywhere enum values are rendered.

###Test plan:

- [x]   Open the orders dashboard for any event — confirm status shows "Pending Invoice", "Partially Refunded", etc.
- [x]   Open the status filter dropdown — confirm human-readable options, then filter by one and confirm results match.
- [x]   Check the payment filter — confirm "Stripe" appears, not "PAYPAL".
- [x]   Export orders as CSV — confirm status and paymentMethod columns contain readable values.

---
###Issue #347 — Checkout form only validates on submit

  Problem: All buyer and attendee field errors appeared at once when the submit button was
  clicked, with no per-field feedback while filling in the form.

  Fix: Added progressive validation using the same Zod schemas as the server (buyerInfoSchema,   checkoutAttendeeSchema).

###Test plan:

- [x]   Open a checkout page, tab through First Name leaving it blank — confirm "First name is required" appears immediately below the field.
- [x]   Enter an invalid email and blur — confirm "Invalid email address" appears. Correct it — confirm error clears.
- [x]   Do not touch any field; click submit — confirm all required fields show inline errors simultaneously, no native browser popup.
- [x]   Fix all errors and submit — confirm the order proceeds normally.

---
###Issue #339 — Missing try/catch in ticket verify route

  Problem: GET and POST handlers in src/app/api/tickets/verify/[code]/route.ts had no error
  handling. Any uncaught exception (DB down, invalid params) would bubble to Next.js's default   handler and could leak a stack trace to the client.

  Fix: Wrapped both handler bodies in try/catch matching the codebase-wide pattern: log the
  raw error server-side, return a generic { error: 'Internal server error' } with status 500.

  Files changed:
  - src/app/api/tickets/verify/[code]/route.ts

  Test plan:

- [x]   Shut down the database and hit GET /api/tickets/verify/some-code — confirm response is {"error": "Internal server error" } with status 500, no stack trace in the body.
- [x]   Same with POST — confirm identical sanitised response.
- [x]   Confirm the error is printed in the server log.
