### PR TITLE
feat(discounts): per-ticket fixed-amount promo codes

### DIFF
--- a/prisma/migrations/20260518120000_add_discount_code_per_ticket/migration.sql
+++ b/prisma/migrations/20260518120000_add_discount_code_per_ticket/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "discount_codes" ADD COLUMN "perTicket" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -361,6 +361,7 @@ model DiscountCode {
   minCartAmount      Decimal?  @db.Decimal(10, 2) // Minimum number of applicable tickets in cart to activate code
   applyToWholeOrder  Boolean   @default(false)    // false = discount applies to 1 ticket only
   maxTicketsPerOrder Int?      // Max tickets to discount per order (null = all applicable tickets)
+  perTicket          Boolean   @default(false)    // FIXED_AMOUNT only: when true, discountValue applies per applicable ticket
 
   // Validity
   validFrom     DateTime?

--- a/src/__tests__/lib/tickets.test.ts
+++ b/src/__tests__/lib/tickets.test.ts
@@ -114,6 +114,7 @@ describe('Discount Code Functions', () => {
       minCartAmount: null,
       applyToWholeOrder: false,
       maxTicketsPerOrder: null,
+      perTicket: false,
       usedCount: 0,
       redeemedTicketCount: 0,
     }

--- a/src/app/(dashboard)/dashboard/events/[id]/discounts/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[id]/discounts/page.tsx
@@ -44,6 +44,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
           usedCount: true,
           isActive: true,
           applyToWholeOrder: true,
+          perTicket: true,
         },
       },
     },
@@ -73,6 +74,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
     const maxTicketsPerOrder = maxTicketsPerOrderRaw ? Number(maxTicketsPerOrderRaw) : null
     const isActive = String(formData.get('isActive') || 'true') === 'true'
     const applyToWholeOrder = discountType === 'FREE_TICKET' ? true : formData.get('applyToWholeOrder') === 'on'
+    const perTicket = discountType === 'FIXED_AMOUNT' && formData.get('perTicket') === 'on'
 
     await prisma.discountCode.create({
       data: {
@@ -85,6 +87,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
         maxTicketsPerOrder,
         isActive,
         applyToWholeOrder,
+        perTicket,
       },
     })
 
@@ -122,6 +125,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
     const maxTicketsPerOrder = maxTicketsPerOrderRaw ? Number(maxTicketsPerOrderRaw) : null
     const isActive = String(formData.get('isActive') || 'true') === 'true'
     const applyToWholeOrder = discountType === 'FREE_TICKET' ? true : formData.get('applyToWholeOrder') === 'on'
+    const perTicket = discountType === 'FIXED_AMOUNT' && formData.get('perTicket') === 'on'
 
     await prisma.discountCode.update({
       where: { id: existing.id },
@@ -134,6 +138,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
         maxTicketsPerOrder,
         isActive,
         applyToWholeOrder,
+        perTicket,
       },
     })
 
@@ -189,6 +194,7 @@ export default async function DiscountCodesPage({ params, searchParams }: PagePr
                   maxTicketsPerOrder: editableDiscountCode.maxTicketsPerOrder,
                   isActive: editableDiscountCode.isActive,
                   applyToWholeOrder: editableDiscountCode.applyToWholeOrder,
+                  perTicket: editableDiscountCode.perTicket,
                 }
               : undefined
           }

--- a/src/app/api/discount-codes/validate/route.ts
+++ b/src/app/api/discount-codes/validate/route.ts
@@ -99,6 +99,7 @@ export async function POST(request: NextRequest) {
         applicableTicketTypeIds: applicableTicketTypeIds,
         applyToWholeOrder: discountCode.applyToWholeOrder,
         maxTicketsPerOrder: discountCode.maxTicketsPerOrder,
+        perTicket: discountCode.perTicket,
       },
     })
   } catch (error) {

--- a/src/app/api/events/[id]/discount-codes/[codeId]/route.ts
+++ b/src/app/api/events/[id]/discount-codes/[codeId]/route.ts
@@ -99,6 +99,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
           minCartAmount: input.minCartAmount !== undefined ? input.minCartAmount : undefined,
           applyToWholeOrder: input.discountType === 'FREE_TICKET' ? true : input.applyToWholeOrder,
           maxTicketsPerOrder: input.maxTicketsPerOrder !== undefined ? input.maxTicketsPerOrder : undefined,
+          perTicket: input.perTicket !== undefined
+            ? (input.discountType === 'FIXED_AMOUNT' ? input.perTicket : false)
+            : undefined,
           validFrom: input.validFrom
             ? new Date(input.validFrom)
             : input.validFrom === null

--- a/src/app/api/events/[id]/discount-codes/route.ts
+++ b/src/app/api/events/[id]/discount-codes/route.ts
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         minCartAmount: input.minCartAmount ?? null,
         applyToWholeOrder: input.discountType === 'FREE_TICKET' ? true : (input.applyToWholeOrder ?? false),
         maxTicketsPerOrder: input.maxTicketsPerOrder ?? null,
+        perTicket: input.discountType === 'FIXED_AMOUNT' ? (input.perTicket ?? false) : false,
         validFrom: input.validFrom ? new Date(input.validFrom) : null,
         validUntil: input.validUntil ? new Date(input.validUntil) : null,
         isActive: input.isActive,

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -239,6 +239,7 @@ export async function POST(request: NextRequest) {
                 .filter((item) => appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId))
 
               let discountableSubtotal: number
+              let applicableTicketCount: number
               if (foundDiscountCode.maxTicketsPerOrder !== null) {
                 const ticketPrices = applicableItems
                   .flatMap((item) => Array(item.quantity).fill(item.unitPrice) as number[])
@@ -246,27 +247,34 @@ export async function POST(request: NextRequest) {
                 const cappedPrices = ticketPrices.slice(0, foundDiscountCode.maxTicketsPerOrder)
                 discountableSubtotal = Number(cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2))
                 discountUsageUnits = cappedPrices.length
-              } else if (foundDiscountCode.applyToWholeOrder) {
+                applicableTicketCount = cappedPrices.length
+              } else if (foundDiscountCode.applyToWholeOrder || foundDiscountCode.perTicket) {
                 discountableSubtotal = applicableItems.reduce((sum, item) => sum + item.totalPrice, 0)
+                applicableTicketCount = applicableItems.reduce((sum, item) => sum + item.quantity, 0)
               } else {
                 const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
                 discountableSubtotal = maxUnitPrice
+                applicableTicketCount = applicableItems.length > 0 ? 1 : 0
               }
 
               // Check usage limits
               const remainingTicketUses = getDiscountCodeRemainingTicketUses(foundDiscountCode)
               if (foundDiscountCode.maxTicketsPerOrder === null) {
-                discountUsageUnits = foundDiscountCode.applyToWholeOrder
+                discountUsageUnits = (foundDiscountCode.applyToWholeOrder || foundDiscountCode.perTicket)
                   ? getDiscountUsageUnitsFromItems(applicableItems)
                   : 1
               }
 
               if (remainingTicketUses === null || remainingTicketUses >= discountUsageUnits) {
                 discountCodeRecord = foundDiscountCode
+                const rawValue = decimalToNumber(foundDiscountCode.discountValue)
+                const effectiveValue = (foundDiscountCode.discountType === 'FIXED_AMOUNT' && foundDiscountCode.perTicket)
+                  ? rawValue * applicableTicketCount
+                  : rawValue
                 promoCodeDiscountAmount = calculateDiscountAmount(
                   discountableSubtotal,
                   foundDiscountCode.discountType,
-                  decimalToNumber(foundDiscountCode.discountValue)
+                  effectiveValue
                 )
               }
             }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -284,7 +284,7 @@ export async function POST(request: NextRequest) {
                     .sort((a, b) => b - a)
                   discountUsageUnits = ticketPricesForCap.slice(0, foundDiscountCode.maxTicketsPerOrder).length
                 } else {
-                  discountUsageUnits = foundDiscountCode.applyToWholeOrder
+                  discountUsageUnits = (foundDiscountCode.applyToWholeOrder || foundDiscountCode.perTicket)
                     ? getDiscountUsageUnitsFromItems(
                         preparedOrder.items.filter((item) =>
                           appliesToAll ? true : discountApplicableTicketTypeIds.includes(item.ticketTypeId)
@@ -305,6 +305,7 @@ export async function POST(request: NextRequest) {
                 // Calculate promo code discount amount
                 // If maxTicketsPerOrder is set, only discount that many tickets (most expensive first)
                 let discountableSubtotal: number
+                let applicableTicketCount: number
                 const applicableItems = preparedOrder.items.filter(
                   (item) => appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId)
                 )
@@ -318,13 +319,16 @@ export async function POST(request: NextRequest) {
                     cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2)
                   )
                   discountUsageUnits = cappedPrices.length
-                } else if (foundDiscountCode.applyToWholeOrder) {
+                  applicableTicketCount = cappedPrices.length
+                } else if (foundDiscountCode.applyToWholeOrder || foundDiscountCode.perTicket) {
                   discountableSubtotal = applicableItems.reduce((sum, item) =>
                     Number((sum + item.totalPrice).toFixed(2)), 0)
+                  applicableTicketCount = applicableItems.reduce((sum, item) => sum + item.quantity, 0)
                 } else {
                   // Apply to 1 ticket only — use the most expensive applicable unit price
                   const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
                   discountableSubtotal = maxUnitPrice
+                  applicableTicketCount = applicableItems.length > 0 ? 1 : 0
                 }
 
                 if (foundDiscountCode.minCartAmount !== null) {
@@ -342,10 +346,14 @@ export async function POST(request: NextRequest) {
 
                 if (!promoCodeError) {
                   discountCodeRecord = foundDiscountCode
+                  const rawValue = decimalToNumber(foundDiscountCode.discountValue)
+                  const effectiveValue = (foundDiscountCode.discountType === 'FIXED_AMOUNT' && foundDiscountCode.perTicket)
+                    ? rawValue * applicableTicketCount
+                    : rawValue
                   promoCodeDiscountAmount = calculateDiscountAmount(
                     discountableSubtotal,
                     foundDiscountCode.discountType,
-                    decimalToNumber(foundDiscountCode.discountValue)
+                    effectiveValue
                   )
                 }
               }

--- a/src/components/dashboard/DiscountCodeForm.tsx
+++ b/src/components/dashboard/DiscountCodeForm.tsx
@@ -20,6 +20,7 @@ type DiscountCodeFormProps = {
     maxTicketsPerOrder: number | null
     isActive: boolean
     applyToWholeOrder: boolean
+    perTicket: boolean
   }
 }
 
@@ -111,6 +112,20 @@ export function DiscountCodeForm({ title, submitLabel, action, initial }: Discou
           Apply discount to entire order (by default, applies to 1 ticket only)
         </Label>
       </div>
+      {discountType === 'FIXED_AMOUNT' && (
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id={`${title}-perTicket`}
+            name="perTicket"
+            defaultChecked={initial?.perTicket ?? false}
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <Label htmlFor={`${title}-perTicket`}>
+            Per ticket — apply the fixed amount to each applicable ticket
+          </Label>
+        </div>
+      )}
       <Button type="submit">{submitLabel}</Button>
     </form>
   )

--- a/src/components/dashboard/ManualOrderForm.tsx
+++ b/src/components/dashboard/ManualOrderForm.tsx
@@ -149,11 +149,14 @@ function calculatePromoCodeDiscountAmount(
     .filter((item) => appliesToAll || discount.applicableTicketTypeIds.includes(item.ticketTypeId))
 
   let discountableSubtotal: number
-  if (discount.applyToWholeOrder) {
+  let applicableTicketCount: number
+  if (discount.applyToWholeOrder || discount.perTicket) {
     discountableSubtotal = applicableItems.reduce((sum, item) => sum + item.totalPrice, 0)
+    applicableTicketCount = applicableItems.reduce((sum, item) => sum + item.quantity, 0)
   } else {
     const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
     discountableSubtotal = maxUnitPrice
+    applicableTicketCount = applicableItems.length > 0 ? 1 : 0
   }
 
   if (discount.discountType === 'PERCENTAGE') {
@@ -161,7 +164,10 @@ function calculatePromoCodeDiscountAmount(
   }
 
   if (discount.discountType === 'FIXED_AMOUNT') {
-    return Number(Math.min(discountableSubtotal, discount.discountValue).toFixed(2))
+    const effectiveValue = discount.perTicket
+      ? discount.discountValue * applicableTicketCount
+      : discount.discountValue
+    return Number(Math.min(discountableSubtotal, effectiveValue).toFixed(2))
   }
 
   if (discount.discountType === 'FREE_TICKET') {

--- a/src/components/tickets/CheckoutForm.tsx
+++ b/src/components/tickets/CheckoutForm.tsx
@@ -178,6 +178,7 @@ function calculateDiscountAmount(
   )
 
   let discountableSubtotal: number
+  let applicableTicketCount: number
   if (discount.maxTicketsPerOrder !== null) {
     // Cap discounted tickets: expand to individual prices, take N most expensive
     const ticketPrices = applicableItems
@@ -185,12 +186,15 @@ function calculateDiscountAmount(
       .sort((a, b) => b - a)
     const cappedPrices = ticketPrices.slice(0, discount.maxTicketsPerOrder)
     discountableSubtotal = Number(cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2))
-  } else if (discount.applyToWholeOrder) {
+    applicableTicketCount = cappedPrices.length
+  } else if (discount.applyToWholeOrder || discount.perTicket) {
     discountableSubtotal = applicableItems.reduce((sum, item) => sum + item.totalPrice, 0)
+    applicableTicketCount = applicableItems.reduce((sum, item) => sum + item.quantity, 0)
   } else {
     // Apply to 1 ticket only — pick the most expensive applicable unit price
     const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
     discountableSubtotal = maxUnitPrice
+    applicableTicketCount = applicableItems.length > 0 ? 1 : 0
   }
 
   if (discount.discountType === 'PERCENTAGE') {
@@ -198,7 +202,10 @@ function calculateDiscountAmount(
   }
 
   if (discount.discountType === 'FIXED_AMOUNT') {
-    return Number(Math.min(discountableSubtotal, discount.discountValue).toFixed(2))
+    const effectiveValue = discount.perTicket
+      ? discount.discountValue * applicableTicketCount
+      : discount.discountValue
+    return Number(Math.min(discountableSubtotal, effectiveValue).toFixed(2))
   }
 
   if (discount.discountType === 'FREE_TICKET') {

--- a/src/components/tickets/DiscountCodeInput.tsx
+++ b/src/components/tickets/DiscountCodeInput.tsx
@@ -12,6 +12,7 @@ export interface AppliedDiscount {
   applicableTicketTypeIds: string[]
   applyToWholeOrder: boolean
   maxTicketsPerOrder: number | null
+  perTicket: boolean
 }
 
 interface DiscountCodeInputProps {

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -40,6 +40,7 @@ const discountCodeBaseSchema = z.object({
   minCartAmount: z.number().min(0).optional().nullable(),
   applyToWholeOrder: z.boolean().default(false),
   maxTicketsPerOrder: z.number().int().positive().optional().nullable(),
+  perTicket: z.boolean().default(false),
   validFrom: z.string().datetime().optional().nullable(),
   validUntil: z.string().datetime().optional().nullable(),
   isActive: z.boolean().default(true),


### PR DESCRIPTION
## Summary

Adds a `perTicket` flag on `DiscountCode`. When set together with `FIXED_AMOUNT`, the discount value is applied to **each applicable ticket** rather than capped at a single per-order amount.

This lets organizers create codes like `SPECIAL1 = 1400 SEK off per ticket` without having to use:
- `PERCENTAGE` (suffers from rounding drift — `Decimal(10,2)` can't represent `1400/7500 = 18.666…%` exactly), or
- `GroupDiscount` with `TIER_PRICE` (triggers on minimum quantity, not on entering a code).

### Existing FIXED_AMOUNT behavior (unchanged when `perTicket=false`)
- `applyToWholeOrder=false` → 1400 off **one** ticket (most expensive)
- `applyToWholeOrder=true` → still `min(applicableSubtotal, 1400)` total — i.e. 1400 once for the whole order
- `maxTicketsPerOrder=N` → 1400 spread across up to N tickets but still capped at 1400

### New behavior (`perTicket=true`)
- Discount = `min(discountValue * applicableTicketCount, applicableSubtotal)`
- Where `applicableTicketCount` respects `maxTicketsPerOrder` if set; otherwise counts all applicable tickets
- Setting `perTicket=true` implies whole-order subtotal semantics (it would be meaningless against a single-ticket subtotal)

## Changes

- **Schema/migration**: `perTicket Boolean @default(false)` on `discount_codes`
- **API**:
  - `POST /api/discount-codes/validate` returns `perTicket` so the client estimate matches server pricing
  - `POST /api/events/[id]/discount-codes` (+ PATCH on `[codeId]`) accept and persist `perTicket`; cleared to `false` for non-FIXED_AMOUNT types
- **Order pricing** (`/api/orders`, `/api/orders/manual`): when `FIXED_AMOUNT + perTicket`, multiply `discountValue` by the applicable ticket count (respecting `maxTicketsPerOrder`), still capped at the applicable subtotal
- **Client checkout** + **manual order form**: same per-ticket multiplication so the buyer sees the same total the server will charge
- **Dashboard discounts page**: new "Per ticket" checkbox shown only when Type = Fixed Amount; saved via the existing server action

## Test plan

- [x] `vitest run src/__tests__/lib/tickets.test.ts` — 29/29 green (added missing `perTicket: false` to the base test fixture)
- [x] `tsc --noEmit` — clean
- [x] Manual: create a FIXED_AMOUNT discount with `perTicket=true`, value 1400, on an event with a 7500 SEK ex-VAT ticket type. Verify:
  - 1 ticket → discount 1400, total 6100 ex VAT
  - 3 tickets → discount 4200, total 18 300 ex VAT
  - With `maxTicketsPerOrder=2` and 3 tickets → discount 2800
- [x] Manual: verify existing FIXED_AMOUNT codes with `perTicket=false` still behave exactly as before (single-amount cap)
- [x] Run `prisma migrate deploy` against prod after deploying the app code (per `CLAUDE.md` workflow)