### PR TITLE
refactor(orders): extract shared order creation logic into createOrder

### DIFF
--- a/src/__tests__/lib/createOrder.test.ts
+++ b/src/__tests__/lib/createOrder.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for createOrder (src/lib/orders/createOrder.ts)
+ *
+ * Covers both entry points:
+ *   - Public checkout  (isManualOrder: false, the default)
+ *   - Dashboard manual order (isManualOrder: true)
+ */
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { Prisma } from '@prisma/client'
+import {
+  createOrder,
+  calculateGroupDiscountAmount,
+  type GroupDiscountRecord,
+} from '@/lib/orders/createOrder'
+import { prisma } from '@/lib/db'
+import { prepareOrderItems } from '@/lib/orders'
+import {
+  getCheckoutUnavailableReason,
+  getOrderErrorForCheckoutUnavailableReason,
+} from '@/lib/orders/checkoutAvailability'
+import { isTicketAvailable } from '@/lib/utils'
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/db', () => ({
+  prisma: { $transaction: vi.fn() },
+}))
+
+vi.mock('@/lib/orders', () => ({
+  lockTicketTypes: vi.fn().mockResolvedValue(undefined),
+  prepareOrderItems: vi.fn(),
+  generateTicketCreateInput: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('@/lib/orders/checkoutAvailability', () => ({
+  getCheckoutUnavailableReason: vi.fn(),
+  getOrderErrorForCheckoutUnavailableReason: vi.fn(
+    () => 'Event is not open for ticket sales'
+  ),
+}))
+
+vi.mock('@/lib/orders/discountUsage', () => ({
+  claimDiscountCodeUsage: vi.fn().mockResolvedValue(true),
+  getDiscountUsageUnitsFromItems: vi.fn().mockReturnValue(0),
+}))
+
+vi.mock('@/lib/tickets', () => ({
+  calculateDiscountAmount: vi.fn().mockReturnValue(0),
+  decimalToNumber: vi.fn((d: Prisma.Decimal | number) =>
+    typeof d === 'number' ? d : parseFloat(d.toString())
+  ),
+  getApplicableTicketTypeIds: vi.fn().mockReturnValue([]),
+  getDiscountCodeRemainingTicketUses: vi.fn().mockReturnValue(null),
+  normalizeDiscountCode: vi.fn((code: string) => code.toUpperCase()),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  generateOrderNumber: vi.fn().mockReturnValue('ORD-0001'),
+  isTicketAvailable: vi.fn(),
+  formatDateTime: vi.fn().mockReturnValue('2026-06-01 10:00'),
+}))
+
+vi.mock('@/lib/pricing/vatRates', () => ({
+  getVatRateForCountryNameOrCode: vi.fn().mockReturnValue(0),
+}))
+
+vi.mock('@/lib/pricing/vat', () => ({
+  getIncludedVatFromVatInclusiveTotal: vi.fn().mockReturnValue(0),
+}))
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const BASE_INPUT = {
+  eventId: 'event-1',
+  buyer: {
+    firstName: 'Anna',
+    lastName: 'Svensson',
+    email: 'anna@example.com',
+    organization: 'ACME',
+    address: 'Storgatan 1',
+    city: 'Stockholm',
+    postalCode: '11111',
+    country: 'SE',
+    title: 'Ms',
+  },
+  items: [{ ticketTypeId: 'tt-1', quantity: 2 }],
+}
+
+const MOCK_EVENT = {
+  id: 'event-1',
+  title: 'Test Event',
+  slug: 'test-event',
+  startDate: new Date('2026-06-01'),
+  endDate: new Date('2026-06-01'),
+  locationType: 'VENUE',
+  venue: 'Test Venue',
+  city: 'Stockholm',
+  country: 'SE',
+  onlineUrl: null,
+  status: 'PUBLISHED',
+  ticketTypes: [
+    {
+      salesStartDate: new Date('2026-01-01'),
+      salesEndDate: new Date('2026-12-31'),
+      maxCapacity: 100,
+      soldCount: 10,
+      reservedCount: 0,
+      isVisible: true,
+    },
+  ],
+}
+
+const MOCK_TICKET_TYPES = [
+  {
+    id: 'tt-1',
+    name: 'General Admission',
+    price: new Prisma.Decimal(200),
+    currency: 'SEK',
+    minPerOrder: 1,
+    maxPerOrder: 10,
+    maxCapacity: 100,
+    soldCount: 10,
+    reservedCount: 0,
+    salesStartDate: new Date('2026-01-01'),
+    salesEndDate: new Date('2026-12-31'),
+  },
+]
+
+const FINAL_ORDER_STUB = {
+  id: 'order-1',
+  orderNumber: 'ORD-0001',
+  status: 'PAID',
+  paymentMethod: 'FREE',
+  totalAmount: new Prisma.Decimal(0),
+  discountAmount: new Prisma.Decimal(400),
+  subtotal: new Prisma.Decimal(400),
+  vatRate: new Prisma.Decimal(0),
+  vatAmount: new Prisma.Decimal(0),
+  currency: 'SEK',
+  buyerEmail: 'anna@example.com',
+  buyerFirstName: 'Anna',
+  buyerLastName: 'Svensson',
+  expiresAt: null,
+  paidAt: new Date(),
+  items: [
+    {
+      ticketType: { name: 'General Admission' },
+      quantity: 2,
+      totalPrice: new Prisma.Decimal(400),
+      unitPrice: new Prisma.Decimal(200),
+    },
+  ],
+  tickets: [],
+  groupDiscount: null,
+  discountCode: null,
+  event: {
+    id: 'event-1',
+    title: 'Test Event',
+    startDate: new Date('2026-06-01'),
+    locationType: 'VENUE',
+    venue: 'Test Venue',
+    city: 'Stockholm',
+    country: 'SE',
+    onlineUrl: null,
+    organizer: { user: { email: 'organizer@example.com' } },
+  },
+}
+
+const NON_FREE_PREPARED_ORDER = {
+  items: [{ ticketTypeId: 'tt-1', quantity: 2, unitPrice: 200, totalPrice: 400, currency: 'SEK' }],
+  subtotal: 400,
+}
+
+const FREE_PREPARED_ORDER = {
+  items: [{ ticketTypeId: 'tt-1', quantity: 1, unitPrice: 0, totalPrice: 0, currency: 'SEK' }],
+  subtotal: 0,
+}
+
+// ── Fake transaction builder ──────────────────────────────────────────────────
+
+function buildFakeTx() {
+  return {
+    event: {
+      findUnique: vi.fn().mockResolvedValue(MOCK_EVENT),
+    },
+    ticketType: {
+      findMany: vi.fn().mockResolvedValue(MOCK_TICKET_TYPES),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    order: {
+      create: vi.fn().mockResolvedValue({ id: 'order-1' }),
+      findUniqueOrThrow: vi.fn().mockResolvedValue(FINAL_ORDER_STUB),
+    },
+    orderItem: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    ticket: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    discountCode: { findUnique: vi.fn().mockResolvedValue(null) },
+    groupDiscount: { findUnique: vi.fn().mockResolvedValue(null) },
+  }
+}
+
+function setupTransaction(fakeTx: ReturnType<typeof buildFakeTx>) {
+  ;(prisma.$transaction as Mock).mockImplementation(
+    (callback: (tx: unknown) => Promise<unknown>) => callback(fakeTx)
+  )
+}
+
+// ── calculateGroupDiscountAmount ──────────────────────────────────────────────
+
+describe('calculateGroupDiscountAmount', () => {
+  // total qty = 5, subtotal = 400
+  const items = [
+    { ticketTypeId: 'tt-1', quantity: 3, unitPrice: 100, totalPrice: 300 },
+    { ticketTypeId: 'tt-2', quantity: 2, unitPrice: 50, totalPrice: 100 },
+  ]
+
+  function makeGd(overrides: Partial<GroupDiscountRecord>): GroupDiscountRecord {
+    return {
+      id: 'gd-1',
+      ticketTypeId: null,
+      minQuantity: 4,
+      discountType: 'PERCENTAGE',
+      discountValue: new Prisma.Decimal(10),
+      isActive: true,
+      ...overrides,
+    }
+  }
+
+  it('returns 0 when global quantity is below minQuantity', () => {
+    expect(calculateGroupDiscountAmount(makeGd({ minQuantity: 10 }), items, 0)).toBe(0)
+  })
+
+  it('applies global PERCENTAGE discount', () => {
+    // 10% of subtotal 400 = 40
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ minQuantity: 4, discountType: 'PERCENTAGE', discountValue: new Prisma.Decimal(10) }),
+        items,
+        0
+      )
+    ).toBe(40)
+  })
+
+  it('applies global TIER_PRICE discount', () => {
+    // Target unit price 80 (vatRate=0 so no adjustment).
+    // tt-1: (100-80)*3 = 60; tt-2: max(0, 50-80)*2 = 0 → total reduction = 60
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ minQuantity: 4, discountType: 'TIER_PRICE', discountValue: new Prisma.Decimal(80) }),
+        items,
+        0
+      )
+    ).toBe(60)
+  })
+
+  it('applies global FIXED discount', () => {
+    // Fixed 50 off a 400 subtotal → 50
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ minQuantity: 4, discountType: 'FIXED', discountValue: new Prisma.Decimal(50) }),
+        items,
+        0
+      )
+    ).toBe(50)
+  })
+
+  it('caps global FIXED discount at subtotal', () => {
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ minQuantity: 4, discountType: 'FIXED', discountValue: new Prisma.Decimal(1000) }),
+        items,
+        0
+      )
+    ).toBe(400)
+  })
+
+  it('applies per-ticket PERCENTAGE discount when item quantity is met', () => {
+    // tt-1 qty=3 >= minQuantity=2; 20% of 300 = 60
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ ticketTypeId: 'tt-1', minQuantity: 2, discountType: 'PERCENTAGE', discountValue: new Prisma.Decimal(20) }),
+        items,
+        0
+      )
+    ).toBe(60)
+  })
+
+  it('returns 0 for per-ticket discount when item quantity is below minQuantity', () => {
+    // tt-2 qty=2, minQuantity=5 → 0
+    expect(
+      calculateGroupDiscountAmount(
+        makeGd({ ticketTypeId: 'tt-2', minQuantity: 5 }),
+        items,
+        0
+      )
+    ).toBe(0)
+  })
+})
+
+// ── createOrder: public checkout ─────────────────────────────────────────────
+
+describe('createOrder (public checkout, isManualOrder: false)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prepareOrderItems as Mock).mockReturnValue(NON_FREE_PREPARED_ORDER)
+    ;(getCheckoutUnavailableReason as Mock).mockReturnValue(null)
+    ;(isTicketAvailable as Mock).mockReturnValue(true)
+  })
+
+  it('creates a PENDING/PAYPAL order for a non-free order', async () => {
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await createOrder(BASE_INPUT)
+
+    const { status, paymentMethod } = fakeTx.order.create.mock.calls[0][0].data
+    expect(status).toBe('PENDING')
+    expect(paymentMethod).toBe('PAYPAL')
+  })
+
+  it('creates a PAID/FREE order when total is zero', async () => {
+    ;(prepareOrderItems as Mock).mockReturnValue(FREE_PREPARED_ORDER)
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await createOrder(BASE_INPUT)
+
+    const { status, paymentMethod } = fakeTx.order.create.mock.calls[0][0].data
+    expect(status).toBe('PAID')
+    expect(paymentMethod).toBe('FREE')
+  })
+
+  it('throws and does not create an order when checkout is unavailable', async () => {
+    ;(getCheckoutUnavailableReason as Mock).mockReturnValue('NOT_OPEN')
+    ;(getOrderErrorForCheckoutUnavailableReason as Mock).mockReturnValue(
+      'Event is not open for ticket sales'
+    )
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await expect(createOrder(BASE_INPUT)).rejects.toThrow('Event is not open for ticket sales')
+    expect(fakeTx.order.create).not.toHaveBeenCalled()
+  })
+
+  it('throws and does not create an order when a ticket type is unavailable', async () => {
+    ;(isTicketAvailable as Mock).mockReturnValue(false)
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await expect(createOrder(BASE_INPUT)).rejects.toThrow('is not currently available')
+    expect(fakeTx.order.create).not.toHaveBeenCalled()
+  })
+
+  it('throws when the discount code does not exist', async () => {
+    const fakeTx = buildFakeTx()
+    fakeTx.discountCode.findUnique.mockResolvedValue(null)
+    setupTransaction(fakeTx)
+
+    await expect(
+      createOrder({ ...BASE_INPUT, discountCode: 'BADCODE' })
+    ).rejects.toThrow('Discount code not found')
+  })
+})
+
+// ── createOrder: manual order ─────────────────────────────────────────────────
+
+describe('createOrder (manual order, isManualOrder: true)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(prepareOrderItems as Mock).mockReturnValue(NON_FREE_PREPARED_ORDER)
+    ;(getCheckoutUnavailableReason as Mock).mockReturnValue(null)
+    ;(isTicketAvailable as Mock).mockReturnValue(true)
+  })
+
+  it('creates a PENDING_INVOICE/INVOICE order for a non-free order', async () => {
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await createOrder(BASE_INPUT, { isManualOrder: true })
+
+    const { status, paymentMethod } = fakeTx.order.create.mock.calls[0][0].data
+    expect(status).toBe('PENDING_INVOICE')
+    expect(paymentMethod).toBe('INVOICE')
+  })
+
+  it('creates a PAID/FREE order when total is zero', async () => {
+    ;(prepareOrderItems as Mock).mockReturnValue(FREE_PREPARED_ORDER)
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await createOrder(BASE_INPUT, { isManualOrder: true })
+
+    const { status, paymentMethod } = fakeTx.order.create.mock.calls[0][0].data
+    expect(status).toBe('PAID')
+    expect(paymentMethod).toBe('FREE')
+  })
+
+  it('proceeds when checkout is unavailable (skips availability check)', async () => {
+    ;(getCheckoutUnavailableReason as Mock).mockReturnValue('NOT_OPEN')
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await expect(createOrder(BASE_INPUT, { isManualOrder: true })).resolves.toBeDefined()
+    expect(fakeTx.order.create).toHaveBeenCalled()
+  })
+
+  it('proceeds when the ticket sales window is closed (skips per-ticket availability check)', async () => {
+    ;(isTicketAvailable as Mock).mockReturnValue(false)
+    const fakeTx = buildFakeTx()
+    setupTransaction(fakeTx)
+
+    await expect(createOrder(BASE_INPUT, { isManualOrder: true })).resolves.toBeDefined()
+    expect(fakeTx.order.create).toHaveBeenCalled()
+  })
+
+  it('proceeds and ignores an invalid discount code without throwing', async () => {
+    const fakeTx = buildFakeTx()
+    fakeTx.discountCode.findUnique.mockResolvedValue(null)
+    setupTransaction(fakeTx)
+
+    await expect(
+      createOrder({ ...BASE_INPUT, discountCode: 'BADCODE' }, { isManualOrder: true })
+    ).resolves.toBeDefined()
+
+    const { discountCodeId } = fakeTx.order.create.mock.calls[0][0].data
+    expect(discountCodeId).toBeNull()
+  })
+})

--- a/src/app/api/orders/manual/route.ts
+++ b/src/app/api/orders/manual/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
-import { Prisma } from '@prisma/client'
 import { requireAuth } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import {
@@ -8,110 +7,16 @@ import {
   sendOrderConfirmationEmail,
   sendAttendeeTicketEmailsForOrder,
 } from '@/lib/email'
-import { generateTicketCreateInput, lockTicketTypes, prepareOrderItems } from '@/lib/orders'
-import { claimDiscountCodeUsage, getDiscountUsageUnitsFromItems } from '@/lib/orders/discountUsage'
-import {
-  calculateDiscountAmount,
-  decimalToNumber,
-  getApplicableTicketTypeIds,
-  getDiscountCodeRemainingTicketUses,
-  normalizeDiscountCode,
-} from '@/lib/tickets'
-import { formatDateTime, generateOrderNumber } from '@/lib/utils'
-import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
-import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
-import { z } from 'zod'
-
-type DiscountCodeWithLinks = Prisma.DiscountCodeGetPayload<{
-  include: { ticketTypes: true }
-}>
-
-type GroupDiscountRecord = {
-  id: string
-  ticketTypeId: string | null
-  minQuantity: number
-  discountType: string
-  discountValue: Prisma.Decimal
-  isActive: boolean
-}
-
-function calculateGroupDiscountAmount(
-  groupDiscount: GroupDiscountRecord,
-  items: { ticketTypeId: string; quantity: number; unitPrice: number; totalPrice: number }[],
-  vatRate: number
-): number {
-  const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
-  const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0)
-  const value = decimalToNumber(groupDiscount.discountValue)
-  const targetUnitInclVat = value * (1 + (vatRate ?? 0))
-
-  if (groupDiscount.ticketTypeId === null) {
-    if (totalQuantity < groupDiscount.minQuantity) return 0
-
-    if (groupDiscount.discountType === 'PERCENTAGE') {
-      return Number(Math.min(subtotal, (subtotal * value) / 100).toFixed(2))
-    } else if (groupDiscount.discountType === 'TIER_PRICE') {
-      const reduced = items.reduce(
-        (sum, item) => sum + Math.max(0, item.unitPrice - targetUnitInclVat) * item.quantity,
-        0
-      )
-      return Number(Math.min(subtotal, reduced).toFixed(2))
-    } else {
-      return Number(Math.min(subtotal, value).toFixed(2))
-    }
-  } else {
-    const applicableItem = items.find(item => item.ticketTypeId === groupDiscount.ticketTypeId)
-    if (!applicableItem || applicableItem.quantity < groupDiscount.minQuantity) return 0
-
-    if (groupDiscount.discountType === 'PERCENTAGE') {
-      return Number(Math.min(applicableItem.totalPrice, (applicableItem.totalPrice * value) / 100).toFixed(2))
-    } else if (groupDiscount.discountType === 'TIER_PRICE') {
-      const reduced = Math.max(0, applicableItem.unitPrice - targetUnitInclVat) * applicableItem.quantity
-      return Number(Math.min(applicableItem.totalPrice, reduced).toFixed(2))
-    } else {
-      return Number(Math.min(applicableItem.totalPrice, value).toFixed(2))
-    }
-  }
-}
-
-const manualOrderAttendeeSchema = z.object({
-  firstName: z.string().min(1, 'First name is required'),
-  lastName: z.string().min(1, 'Last name is required'),
-  email: z.string().email('Invalid email address'),
-  title: z.string().optional(),
-  organization: z.string().min(1, 'Organization is required'),
-})
-
-const manualOrderItemSchema = z.object({
-  ticketTypeId: z.string().min(1),
-  quantity: z.number().int().min(1, 'Quantity must be at least 1'),
-  attendees: z.array(manualOrderAttendeeSchema).optional(),
-})
-
-const createManualOrderSchema = z.object({
-  eventId: z.string().cuid(),
-  items: z.array(manualOrderItemSchema).min(1, 'At least one ticket is required'),
-  buyer: z.object({
-    firstName: z.string().min(1, 'First name is required'),
-    lastName: z.string().min(1, 'Last name is required'),
-    title: z.string().optional(),
-    email: z.string().email('Invalid email address'),
-    organization: z.string().min(1, 'Organization is required'),
-    address: z.string().optional(),
-    city: z.string().optional(),
-    postalCode: z.string().optional(),
-    country: z.string().optional(),
-  }),
-  discountCode: z.string().optional(),
-  groupDiscountId: z.string().cuid().optional(),
-})
+import { createOrder } from '@/lib/orders/createOrder'
+import { createOrderSchema } from '@/lib/validations'
+import { formatDateTime } from '@/lib/utils'
 
 export async function POST(request: NextRequest) {
   try {
     const user = await requireAuth()
 
     const body = await request.json()
-    const parsed = createManualOrderSchema.safeParse(body)
+    const parsed = createOrderSchema.safeParse(body)
 
     if (!parsed.success) {
       return NextResponse.json(
@@ -122,22 +27,15 @@ export async function POST(request: NextRequest) {
 
     const input = parsed.data
 
-    // Verify organizer permission for the event
+    // Verify the event exists and the caller has organizer access before
+    // starting the transaction.
     const event = await prisma.event.findUnique({
       where: { id: input.eventId },
       select: {
         id: true,
-        title: true,
-        status: true,
-        country: true,
         organizer: {
           select: {
-            id: true,
-            user: {
-              select: {
-                email: true,
-              },
-            },
+            user: { select: { email: true } },
           },
         },
       },
@@ -147,7 +45,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 })
     }
 
-    const hasOrganizerRole = user.roles.includes('ORGANIZER') || user.roles.includes('SUPER_ADMIN')
+    const hasOrganizerRole =
+      user.roles.includes('ORGANIZER') || user.roles.includes('SUPER_ADMIN')
     if (!hasOrganizerRole) {
       return NextResponse.json(
         { error: 'Only event organizers can create manual orders' },
@@ -155,389 +54,74 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const ticketTypeIds = Array.from(new Set(input.items.map((item) => item.ticketTypeId)))
-
-    const createdOrder = await prisma.$transaction(
-      async (tx) => {
-        await lockTicketTypes(tx, ticketTypeIds)
-
-        const ticketTypes = await tx.ticketType.findMany({
-          where: {
-            eventId: input.eventId,
-            id: { in: ticketTypeIds },
-          },
-          select: {
-            id: true,
-            name: true,
-            price: true,
-            currency: true,
-            minPerOrder: true,
-            maxPerOrder: true,
-            maxCapacity: true,
-            soldCount: true,
-            reservedCount: true,
-          },
-        })
-
-        if (ticketTypes.length !== ticketTypeIds.length) {
-          throw new Error('One or more ticket types were not found for this event')
-        }
-
-        // Check capacity for each item
-        for (const item of input.items) {
-          const ticketType = ticketTypes.find((t) => t.id === item.ticketTypeId)
-          if (!ticketType) {
-            throw new Error(`Ticket type ${item.ticketTypeId} not found`)
-          }
-
-          if (ticketType.maxCapacity !== null) {
-            const remaining = ticketType.maxCapacity - ticketType.soldCount - ticketType.reservedCount
-            if (remaining < item.quantity) {
-              throw new Error(
-                `${ticketType.name} does not have enough remaining capacity (${remaining} left)`
-              )
-            }
-          }
-        }
-
-        const vatRate = getVatRateForCountryNameOrCode(event.country ?? '')
-        const preparedOrder = prepareOrderItems(ticketTypes, input.items, { vatRate })
-
-        const subtotal = preparedOrder.subtotal
-
-        // Handle discount codes and group discounts
-        let discountCodeRecord: DiscountCodeWithLinks | null = null
-        let discountUsageUnits = 0
-        let discountApplicableTicketTypeIds: string[] = []
-        let promoCodeDiscountAmount = 0
-
-        if (input.discountCode) {
-          const foundDiscountCode = await tx.discountCode.findUnique({
-            where: {
-              eventId_code: {
-                eventId: input.eventId,
-                code: normalizeDiscountCode(input.discountCode),
-              },
-            },
-            include: {
-              ticketTypes: true,
-            },
-          })
-
-          if (foundDiscountCode && foundDiscountCode.isActive) {
-            // Check validity period
-            const now = new Date()
-            const validFrom = foundDiscountCode.validFrom
-            const validUntil = foundDiscountCode.validUntil
-
-            if ((!validFrom || validFrom <= now) && (!validUntil || validUntil > now)) {
-              discountApplicableTicketTypeIds = getApplicableTicketTypeIds(foundDiscountCode)
-
-              // Calculate discountable subtotal
-              const appliesToAll = discountApplicableTicketTypeIds.length === 0
-              const applicableItems = preparedOrder.items
-                .filter((item) => appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId))
-
-              let discountableSubtotal: number
-              if (foundDiscountCode.maxTicketsPerOrder !== null) {
-                const ticketPrices = applicableItems
-                  .flatMap((item) => Array(item.quantity).fill(item.unitPrice) as number[])
-                  .sort((a, b) => b - a)
-                const cappedPrices = ticketPrices.slice(0, foundDiscountCode.maxTicketsPerOrder)
-                discountableSubtotal = Number(cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2))
-                discountUsageUnits = cappedPrices.length
-              } else if (foundDiscountCode.applyToWholeOrder) {
-                discountableSubtotal = applicableItems.reduce((sum, item) => sum + item.totalPrice, 0)
-              } else {
-                const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
-                discountableSubtotal = maxUnitPrice
-              }
-
-              // Check usage limits
-              const remainingTicketUses = getDiscountCodeRemainingTicketUses(foundDiscountCode)
-              if (foundDiscountCode.maxTicketsPerOrder === null) {
-                discountUsageUnits = foundDiscountCode.applyToWholeOrder
-                  ? getDiscountUsageUnitsFromItems(applicableItems)
-                  : 1
-              }
-
-              if (remainingTicketUses === null || remainingTicketUses >= discountUsageUnits) {
-                discountCodeRecord = foundDiscountCode
-                promoCodeDiscountAmount = calculateDiscountAmount(
-                  discountableSubtotal,
-                  foundDiscountCode.discountType,
-                  decimalToNumber(foundDiscountCode.discountValue)
-                )
-              }
-            }
-          }
-        }
-
-        // Fetch and validate group discount if provided
-        let groupDiscountRecord: GroupDiscountRecord | null = null
-        let groupDiscountAmount = 0
-
-        if (input.groupDiscountId) {
-          const gd = await tx.groupDiscount.findUnique({
-            where: { id: input.groupDiscountId },
-            select: {
-              id: true,
-              eventId: true,
-              ticketTypeId: true,
-              minQuantity: true,
-              discountType: true,
-              discountValue: true,
-              isActive: true,
-            },
-          })
-
-          if (gd && gd.eventId === input.eventId && gd.isActive) {
-            groupDiscountRecord = gd
-            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items, vatRate)
-          }
-        }
-
-        // Apply discounts based on discount code type
-        let discountAmount = 0
-        let appliedDiscountCodeId: string | null = null
-        let appliedGroupDiscountId: string | null = null
-
-        const isInvoiceCode = discountCodeRecord?.discountType === 'INVOICE'
-        const isFreeNonInvoiceCode = discountCodeRecord && !isInvoiceCode &&
-          (discountCodeRecord.discountType === 'FREE_TICKET' ||
-           (discountCodeRecord.discountType === 'PERCENTAGE' && decimalToNumber(discountCodeRecord.discountValue) >= 100))
-
-        if (isInvoiceCode) {
-          // Invoice codes stack with group discounts
-          discountAmount = groupDiscountAmount
-          appliedGroupDiscountId = groupDiscountRecord?.id ?? null
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-          discountUsageUnits = 0
-        } else if (isFreeNonInvoiceCode) {
-          // Non-invoice 100% off codes: order is free
-          discountAmount = promoCodeDiscountAmount
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-        } else if (groupDiscountAmount > promoCodeDiscountAmount) {
-          discountAmount = groupDiscountAmount
-          appliedGroupDiscountId = groupDiscountRecord?.id ?? null
-        } else if (promoCodeDiscountAmount > 0) {
-          discountAmount = promoCodeDiscountAmount
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-        }
-
-        const totalAmount = Number(Math.max(0, subtotal - discountAmount).toFixed(2))
-        const vatAmount = getIncludedVatFromVatInclusiveTotal(totalAmount, vatRate)
-
-        // Free manual orders skip the invoice flow entirely — we don't invoice
-        // anyone for a zero-total order.
-        const isFreeOrder = totalAmount === 0
-        const orderStatus = isFreeOrder ? 'PAID' : 'PENDING_INVOICE'
-        const orderPaymentMethod = isFreeOrder ? 'FREE' : 'INVOICE'
-
-        const order = await tx.order.create({
-          data: {
-            orderNumber: generateOrderNumber(),
-            userId: null, // Manual orders don't have a user association
-            eventId: input.eventId,
-            discountCodeId: appliedDiscountCodeId,
-            groupDiscountId: appliedGroupDiscountId,
-            buyerFirstName: input.buyer.firstName,
-            buyerLastName: input.buyer.lastName,
-            buyerTitle: input.buyer.title,
-            buyerEmail: input.buyer.email,
-            buyerOrganization: input.buyer.organization,
-            buyerAddress: input.buyer.address,
-            buyerCity: input.buyer.city,
-            buyerPostalCode: input.buyer.postalCode,
-            buyerCountry: input.buyer.country,
-            subtotal,
-            discountAmount,
-            totalAmount,
-            vatRate,
-            vatAmount,
-            currency: ticketTypes[0]?.currency ?? 'SEK',
-            status: orderStatus,
-            paymentMethod: orderPaymentMethod,
-            expiresAt: null,
-            paidAt: isFreeOrder ? new Date() : null,
-          },
-        })
-
-        // Build attendee data map
-        const attendeesByTicketType = new Map(
-          input.items
-            .filter((item) => item.attendees && item.attendees.length > 0)
-            .map((item) => [item.ticketTypeId, item.attendees!])
-        )
-
-        // Create order items
-        if (preparedOrder.items.length > 0) {
-          await tx.orderItem.createMany({
-            data: preparedOrder.items.map((item) => ({
-              orderId: order.id,
-              ticketTypeId: item.ticketTypeId,
-              quantity: item.quantity,
-              unitPrice: item.unitPrice,
-              totalPrice: item.totalPrice,
-              attendeeData: attendeesByTicketType.get(item.ticketTypeId) ?? undefined,
-            })),
-          })
-        }
-
-        if (isFreeOrder) {
-          // Free manual orders complete immediately: count as sold and mint tickets.
-          for (const item of preparedOrder.items) {
-            await tx.ticketType.update({
-              where: { id: item.ticketTypeId },
-              data: { soldCount: { increment: item.quantity } },
-            })
-          }
-
-          const ticketCreateData = generateTicketCreateInput(
-            order.id,
-            preparedOrder.items.map((item) => ({
-              ...item,
-              attendees: attendeesByTicketType.get(item.ticketTypeId),
-            }))
-          )
-          if (ticketCreateData.length > 0) {
-            await tx.ticket.createMany({ data: ticketCreateData })
-          }
-        } else {
-          for (const item of preparedOrder.items) {
-            await tx.ticketType.update({
-              where: { id: item.ticketTypeId },
-              data: { reservedCount: { increment: item.quantity } },
-            })
-          }
-        }
-
-        // Claim discount code usage if the promo code was applied
-        if (discountCodeRecord && appliedDiscountCodeId && discountUsageUnits > 0) {
-          const usageClaimed = await claimDiscountCodeUsage(
-            tx,
-            discountCodeRecord.id,
-            discountUsageUnits,
-            discountCodeRecord.maxUses
-          )
-
-          if (!usageClaimed) {
-            throw new Error('Discount code has no remaining uses for this quantity of tickets.')
-          }
-        }
-
-        return tx.order.findUniqueOrThrow({
-          where: { id: order.id },
-          include: {
-            items: {
-              include: {
-                ticketType: {
-                  select: { name: true },
-                },
-              },
-            },
-            tickets: true,
-            groupDiscount: {
-              select: {
-                minQuantity: true,
-                discountType: true,
-                discountValue: true,
-              },
-            },
-            discountCode: {
-              select: {
-                code: true,
-              },
-            },
-            event: {
-              select: {
-                id: true,
-                title: true,
-                startDate: true,
-                locationType: true,
-                venue: true,
-                city: true,
-                country: true,
-                onlineUrl: true,
-              },
-            },
-          },
-        })
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      }
-    )
+    const { order } = await createOrder(input, { isManualOrder: true })
 
     revalidateTag('event-analytics', 'max')
     revalidateTag('dashboard-analytics', 'max')
 
-    if (createdOrder.status === 'PAID' && createdOrder.paymentMethod === 'FREE') {
-      // Free manual order: send the buyer their confirmation + tickets directly.
+    if (order.status === 'PAID') {
       const eventLocation =
-        createdOrder.event.locationType === 'ONLINE'
-          ? createdOrder.event.onlineUrl || 'Online event'
-          : [createdOrder.event.venue, createdOrder.event.city, createdOrder.event.country]
-              .filter(Boolean)
-              .join(', ')
-      const eventDate = formatDateTime(createdOrder.event.startDate)
-      const buyerName = `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`
+        order.event.locationType === 'ONLINE'
+          ? order.event.onlineUrl || 'Online event'
+          : [order.event.venue, order.event.city, order.event.country].filter(Boolean).join(', ')
+      const eventDate = formatDateTime(order.event.startDate)
+      const buyerName = `${order.buyerFirstName} ${order.buyerLastName}`
 
-      await sendOrderConfirmationEmail(createdOrder.buyerEmail, {
-        orderNumber: createdOrder.orderNumber,
-        orderId: createdOrder.id,
-        eventTitle: createdOrder.event.title,
+      await sendOrderConfirmationEmail(order.buyerEmail, {
+        orderNumber: order.orderNumber,
+        orderId: order.id,
+        eventTitle: order.event.title,
         eventDate,
         eventLocation,
-        tickets: createdOrder.items.map((item) => ({
+        tickets: order.items.map((item) => ({
           name: item.ticketType.name,
           quantity: item.quantity,
-          price: `${item.totalPrice.toString()} ${createdOrder.currency}`,
+          price: `${item.totalPrice.toString()} ${order.currency}`,
         })),
-        totalAmount: `${createdOrder.totalAmount.toString()} ${createdOrder.currency}`,
+        totalAmount: `${order.totalAmount.toString()} ${order.currency}`,
         buyerName,
-        vatRate: parseFloat(createdOrder.vatRate.toString()),
-        vatAmount: createdOrder.vatAmount.toString(),
-        ticketCodes: createdOrder.tickets.map((t) => t.ticketCode),
+        vatRate: parseFloat(order.vatRate.toString()),
+        vatAmount: order.vatAmount.toString(),
+        ticketCodes: order.tickets.map((t) => t.ticketCode),
       })
 
       await sendAttendeeTicketEmailsForOrder({
-        orderNumber: createdOrder.orderNumber,
-        buyerEmail: createdOrder.buyerEmail,
+        orderNumber: order.orderNumber,
+        buyerEmail: order.buyerEmail,
         buyerName,
-        eventTitle: createdOrder.event.title,
+        eventTitle: order.event.title,
         eventDate,
         eventLocation,
-        tickets: createdOrder.tickets,
-        items: createdOrder.items,
+        tickets: order.tickets,
+        items: order.items,
       })
     } else {
-      // Notify organizer of the new invoice order
-      const organizerEmail = event.organizer.user.email
+      // PENDING_INVOICE — notify the organizer
+      const organizerEmail = order.event.organizer?.user?.email ?? event.organizer.user.email
       if (organizerEmail) {
-        const discountLabel = createdOrder.groupDiscount
-          ? `group ${createdOrder.groupDiscount.minQuantity}+, ${
-              createdOrder.groupDiscount.discountType === 'PERCENTAGE'
-                ? `${Number(createdOrder.groupDiscount.discountValue.toString())}%`
-                : `${Number(createdOrder.groupDiscount.discountValue.toString())} ${createdOrder.currency}`
+        const discountLabel = order.groupDiscount
+          ? `group ${order.groupDiscount.minQuantity}+, ${
+              order.groupDiscount.discountType === 'PERCENTAGE'
+                ? `${Number(order.groupDiscount.discountValue.toString())}%`
+                : `${Number(order.groupDiscount.discountValue.toString())} ${order.currency}`
             } off`
-          : createdOrder.discountCode
-            ? `code ${createdOrder.discountCode.code}`
+          : order.discountCode
+            ? `code ${order.discountCode.code}`
             : null
         await sendInvoiceOrderNotificationEmail(organizerEmail, {
-          orderNumber: createdOrder.orderNumber,
-          eventTitle: createdOrder.event.title,
-          eventId: createdOrder.event.id,
-          buyerName: `${createdOrder.buyerFirstName} ${createdOrder.buyerLastName}`,
-          buyerEmail: createdOrder.buyerEmail,
-          currency: createdOrder.currency,
-          subtotal: Number(createdOrder.subtotal.toString()),
-          discountAmount: Number(createdOrder.discountAmount.toString()),
+          orderNumber: order.orderNumber,
+          eventTitle: order.event.title,
+          eventId: order.event.id,
+          buyerName: `${order.buyerFirstName} ${order.buyerLastName}`,
+          buyerEmail: order.buyerEmail,
+          currency: order.currency,
+          subtotal: Number(order.subtotal.toString()),
+          discountAmount: Number(order.discountAmount.toString()),
           discountLabel,
-          vatRate: createdOrder.vatRate ? parseFloat(createdOrder.vatRate.toString()) : null,
-          vatAmount: createdOrder.vatAmount ? Number(createdOrder.vatAmount.toString()) : null,
-          totalAmount: Number(createdOrder.totalAmount.toString()),
-          tickets: createdOrder.items.map((item) => ({
+          vatRate: order.vatRate ? parseFloat(order.vatRate.toString()) : null,
+          vatAmount: order.vatAmount ? Number(order.vatAmount.toString()) : null,
+          totalAmount: Number(order.totalAmount.toString()),
+          tickets: order.items.map((item) => ({
             name: item.ticketType.name,
             quantity: item.quantity,
             unitPrice: Number(item.unitPrice.toString()),
@@ -548,7 +132,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({
-      order: createdOrder,
+      order,
       message: 'Manual order created successfully',
     })
   } catch (error) {

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,88 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
-import { Prisma } from '@prisma/client'
 import { getSession } from '@/lib/auth'
-import { prisma } from '@/lib/db'
 import {
   sendOrderConfirmationEmail,
   sendInvoiceOrderNotificationEmail,
   sendAttendeeTicketEmailsForOrder,
 } from '@/lib/email'
-import { lockTicketTypes, prepareOrderItems, generateTicketCreateInput } from '@/lib/orders'
-import { claimDiscountCodeUsage, getDiscountUsageUnitsFromItems } from '@/lib/orders/discountUsage'
-import {
-  getCheckoutUnavailableReason,
-  getOrderErrorForCheckoutUnavailableReason,
-} from '@/lib/orders/checkoutAvailability'
+import { createOrder } from '@/lib/orders/createOrder'
 import { getOrderReservationTtlMinutes } from '@/lib/orders/reservation'
-import {
-  calculateDiscountAmount,
-  decimalToNumber,
-  getApplicableTicketTypeIds,
-  getDiscountCodeRemainingTicketUses,
-  normalizeDiscountCode,
-} from '@/lib/tickets'
 import { createOrderSchema } from '@/lib/validations'
-import { formatDateTime, generateOrderNumber, isTicketAvailable } from '@/lib/utils'
-import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
-import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
-
-type DiscountCodeWithLinks = Prisma.DiscountCodeGetPayload<{
-  include: { ticketTypes: true }
-}>
-
-type GroupDiscountRecord = {
-  id: string
-  ticketTypeId: string | null
-  minQuantity: number
-  discountType: string
-  discountValue: Prisma.Decimal
-  isActive: boolean
-}
-
-function calculateGroupDiscountAmount(
-  groupDiscount: GroupDiscountRecord,
-  items: { ticketTypeId: string; quantity: number; unitPrice: number; totalPrice: number }[],
-  vatRate: number
-): number {
-  const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
-  const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0)
-  const value = decimalToNumber(groupDiscount.discountValue)
-  // TIER_PRICE: organizer enters the exact per-ticket price (ex-VAT, matching
-  // ticketType.price convention) that applies when minQuantity is reached.
-  // Convert to VAT-inclusive so it matches the stored item.unitPrice.
-  const targetUnitInclVat = value * (1 + (vatRate ?? 0))
-
-  if (groupDiscount.ticketTypeId === null) {
-    // Global discount - check total quantity
-    if (totalQuantity < groupDiscount.minQuantity) return 0
-
-    if (groupDiscount.discountType === 'PERCENTAGE') {
-      return Number(Math.min(subtotal, (subtotal * value) / 100).toFixed(2))
-    } else if (groupDiscount.discountType === 'TIER_PRICE') {
-      const reduced = items.reduce(
-        (sum, item) => sum + Math.max(0, item.unitPrice - targetUnitInclVat) * item.quantity,
-        0
-      )
-      return Number(Math.min(subtotal, reduced).toFixed(2))
-    } else {
-      return Number(Math.min(subtotal, value).toFixed(2))
-    }
-  } else {
-    // Ticket-specific discount
-    const applicableItem = items.find(item => item.ticketTypeId === groupDiscount.ticketTypeId)
-    if (!applicableItem || applicableItem.quantity < groupDiscount.minQuantity) return 0
-
-    if (groupDiscount.discountType === 'PERCENTAGE') {
-      return Number(Math.min(applicableItem.totalPrice, (applicableItem.totalPrice * value) / 100).toFixed(2))
-    } else if (groupDiscount.discountType === 'TIER_PRICE') {
-      const reduced = Math.max(0, applicableItem.unitPrice - targetUnitInclVat) * applicableItem.quantity
-      return Number(Math.min(applicableItem.totalPrice, reduced).toFixed(2))
-    } else {
-      return Number(Math.min(applicableItem.totalPrice, value).toFixed(2))
-    }
-  }
-}
+import { formatDateTime } from '@/lib/utils'
 
 export async function POST(request: NextRequest) {
   try {
@@ -91,7 +18,7 @@ export async function POST(request: NextRequest) {
         process.env.NEXT_PUBLIC_ORDER_RESERVATION_TTL_MINUTES
     )
 
-    // Get session optionally - allow both authenticated and anonymous orders
+    // Get session optionally — allow both authenticated and anonymous orders
     const session = await getSession()
     const user = session?.user || null
 
@@ -109,18 +36,14 @@ export async function POST(request: NextRequest) {
 
     if (!parsed.success) {
       return NextResponse.json(
-        {
-          error: 'Validation failed',
-          details: parsed.error.flatten(),
-        },
+        { error: 'Validation failed', details: parsed.error.flatten() },
         { status: 400 }
       )
     }
 
     const input = parsed.data
-    // Use buyer email from form - always required regardless of auth status
-    const buyerEmail = input.buyer.email?.trim()
 
+    const buyerEmail = input.buyer.email?.trim()
     if (!buyerEmail) {
       return NextResponse.json(
         { error: 'Buyer email is required to place an order' },
@@ -128,493 +51,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const createdOrder = await prisma.$transaction(
-      async (tx) => {
-        const event = await tx.event.findUnique({
-          where: { id: input.eventId },
-          select: {
-            id: true,
-            title: true,
-            slug: true,
-            startDate: true,
-            endDate: true,
-            locationType: true,
-            venue: true,
-            city: true,
-            country: true,
-            onlineUrl: true,
-            status: true,
-            ticketTypes: {
-              where: { isVisible: true },
-              select: {
-                salesStartDate: true,
-                salesEndDate: true,
-                maxCapacity: true,
-                soldCount: true,
-                reservedCount: true,
-                isVisible: true,
-              },
-            },
-          },
-        })
-
-        if (!event) {
-          throw new Error('Event not found')
-        }
-
-        const checkoutUnavailableReason = getCheckoutUnavailableReason(event)
-        if (checkoutUnavailableReason) {
-          throw new Error(getOrderErrorForCheckoutUnavailableReason(checkoutUnavailableReason))
-        }
-
-        const ticketTypeIds = Array.from(new Set(input.items.map((item) => item.ticketTypeId)))
-
-        await lockTicketTypes(tx, ticketTypeIds)
-
-        const ticketTypes = await tx.ticketType.findMany({
-          where: {
-            eventId: input.eventId,
-            id: {
-              in: ticketTypeIds,
-            },
-          },
-          select: {
-            id: true,
-            name: true,
-            price: true,
-            currency: true,
-            minPerOrder: true,
-            maxPerOrder: true,
-            maxCapacity: true,
-            soldCount: true,
-            reservedCount: true,
-            salesStartDate: true,
-            salesEndDate: true,
-          },
-        })
-
-        if (ticketTypes.length !== ticketTypeIds.length) {
-          throw new Error('One or more ticket types were not found for this event')
-        }
-
-        const vatRate = getVatRateForCountryNameOrCode(event.country ?? '')
-        const preparedOrder = prepareOrderItems(ticketTypes, input.items, { vatRate })
-
-        for (const item of preparedOrder.items) {
-          const ticketType = ticketTypes.find((ticket) => ticket.id === item.ticketTypeId)
-
-          if (!ticketType) {
-            throw new Error('Ticket type not found')
-          }
-
-          const available = isTicketAvailable(
-            ticketType.salesStartDate,
-            ticketType.salesEndDate,
-            ticketType.maxCapacity,
-            ticketType.soldCount,
-            ticketType.reservedCount
-          )
-
-          if (!available) {
-            throw new Error(`${ticketType.name} is not currently available`) // includes sold out / time-window
-          }
-
-          if (ticketType.maxCapacity !== null) {
-            const remaining = ticketType.maxCapacity - ticketType.soldCount - ticketType.reservedCount
-            if (remaining < item.quantity) {
-              throw new Error(
-                `${ticketType.name} does not have enough remaining capacity (${remaining} left)`
-              )
-            }
-          }
-        }
-
-        let discountCodeRecord: DiscountCodeWithLinks | null = null
-        let discountUsageUnits = 0
-        let discountApplicableTicketTypeIds: string[] = []
-        let promoCodeDiscountAmount = 0
-        let promoCodeError: string | null = null // Track promo code validation errors
-
-        if (input.discountCode) {
-          const foundDiscountCode = await tx.discountCode.findUnique({
-            where: {
-              eventId_code: {
-                eventId: input.eventId,
-                code: normalizeDiscountCode(input.discountCode),
-              },
-            },
-            include: {
-              ticketTypes: true,
-            },
-          })
-
-          if (!foundDiscountCode) {
-            promoCodeError = 'Discount code not found'
-          } else {
-            const now = new Date()
-            if (
-              !foundDiscountCode.isActive ||
-              (foundDiscountCode.validFrom && foundDiscountCode.validFrom > now) ||
-              (foundDiscountCode.validUntil && foundDiscountCode.validUntil < now)
-            ) {
-              promoCodeError = 'Discount code is inactive, expired, or fully used'
-            } else {
-              discountApplicableTicketTypeIds = getApplicableTicketTypeIds(foundDiscountCode)
-              const appliesToAll = discountApplicableTicketTypeIds.length === 0
-
-              if (discountApplicableTicketTypeIds.length > 0) {
-                const hasApplicableItem = preparedOrder.items.some((item) =>
-                  discountApplicableTicketTypeIds.includes(item.ticketTypeId)
-                )
-
-                if (!hasApplicableItem) {
-                  promoCodeError = 'Discount code does not apply to selected ticket types'
-                }
-              }
-
-              if (!promoCodeError) {
-                if (foundDiscountCode.maxTicketsPerOrder !== null) {
-                  // discountUsageUnits will be set accurately in the discountableSubtotal block below
-                  // For the maxUses check, use the capped count as an upper bound
-                  const applicableItemsForCap = preparedOrder.items.filter((item) =>
-                    appliesToAll ? true : discountApplicableTicketTypeIds.includes(item.ticketTypeId)
-                  )
-                  const ticketPricesForCap = applicableItemsForCap
-                    .flatMap((item) => Array(item.quantity).fill(item.unitPrice) as number[])
-                    .sort((a, b) => b - a)
-                  discountUsageUnits = ticketPricesForCap.slice(0, foundDiscountCode.maxTicketsPerOrder).length
-                } else {
-                  discountUsageUnits = foundDiscountCode.applyToWholeOrder
-                    ? getDiscountUsageUnitsFromItems(
-                        preparedOrder.items.filter((item) =>
-                          appliesToAll ? true : discountApplicableTicketTypeIds.includes(item.ticketTypeId)
-                        )
-                      )
-                    : 1 // Single-ticket discount uses 1 unit
-                }
-
-                if (foundDiscountCode.maxUses !== null) {
-                  const remainingUses = getDiscountCodeRemainingTicketUses(foundDiscountCode) ?? 0
-                  if (discountUsageUnits > remainingUses) {
-                    promoCodeError = 'Discount code has no remaining uses for this quantity of tickets.'
-                  }
-                }
-              }
-
-              if (!promoCodeError) {
-                // Calculate promo code discount amount
-                // If maxTicketsPerOrder is set, only discount that many tickets (most expensive first)
-                let discountableSubtotal: number
-                const applicableItems = preparedOrder.items.filter(
-                  (item) => appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId)
-                )
-
-                if (foundDiscountCode.maxTicketsPerOrder !== null) {
-                  const ticketPrices = applicableItems
-                    .flatMap((item) => Array(item.quantity).fill(item.unitPrice) as number[])
-                    .sort((a, b) => b - a) // most expensive first
-                  const cappedPrices = ticketPrices.slice(0, foundDiscountCode.maxTicketsPerOrder)
-                  discountableSubtotal = Number(
-                    cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2)
-                  )
-                  discountUsageUnits = cappedPrices.length
-                } else if (foundDiscountCode.applyToWholeOrder) {
-                  discountableSubtotal = applicableItems.reduce((sum, item) =>
-                    Number((sum + item.totalPrice).toFixed(2)), 0)
-                } else {
-                  // Apply to 1 ticket only — use the most expensive applicable unit price
-                  const maxUnitPrice = Math.max(0, ...applicableItems.map((item) => item.unitPrice))
-                  discountableSubtotal = maxUnitPrice
-                }
-
-                if (foundDiscountCode.minCartAmount !== null) {
-                  const minQuantity = decimalToNumber(foundDiscountCode.minCartAmount)
-                  const totalApplicableQuantity = preparedOrder.items.reduce((sum, item) => {
-                    if (appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId)) {
-                      return sum + item.quantity
-                    }
-                    return sum
-                  }, 0)
-                  if (totalApplicableQuantity < minQuantity) {
-                    promoCodeError = `At least ${minQuantity} ticket(s) of the applicable type are required for this discount code`
-                  }
-                }
-
-                if (!promoCodeError) {
-                  discountCodeRecord = foundDiscountCode
-                  promoCodeDiscountAmount = calculateDiscountAmount(
-                    discountableSubtotal,
-                    foundDiscountCode.discountType,
-                    decimalToNumber(foundDiscountCode.discountValue)
-                  )
-                }
-              }
-            }
-          }
-        }
-
-        // Fetch and validate group discount if provided
-        let groupDiscountRecord: GroupDiscountRecord | null = null
-        let groupDiscountAmount = 0
-
-        if (input.groupDiscountId) {
-          const gd = await tx.groupDiscount.findUnique({
-            where: { id: input.groupDiscountId },
-            select: {
-              id: true,
-              eventId: true,
-              ticketTypeId: true,
-              minQuantity: true,
-              discountType: true,
-              discountValue: true,
-              isActive: true,
-            },
-          })
-
-          if (gd && gd.eventId === input.eventId && gd.isActive) {
-            groupDiscountRecord = gd
-            groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items, vatRate)
-          }
-        }
-
-        // Apply discounts based on discount code type
-        const subtotal = preparedOrder.subtotal
-        let discountAmount = 0
-        let appliedGroupDiscountId: string | null = null
-        let appliedDiscountCodeId: string | null = null
-        let promoCodeIgnoredForGroupDiscount = false
-
-        const isInvoiceCode = discountCodeRecord?.discountType === 'INVOICE'
-        const isFreeNonInvoiceCode = discountCodeRecord && !isInvoiceCode &&
-          (discountCodeRecord.discountType === 'FREE_TICKET' ||
-           (discountCodeRecord.discountType === 'PERCENTAGE' && decimalToNumber(discountCodeRecord.discountValue) >= 100))
-
-        if (isInvoiceCode) {
-          // Invoice codes stack with group discounts: apply group discount for price, invoice for payment method
-          discountAmount = groupDiscountAmount
-          appliedGroupDiscountId = groupDiscountRecord?.id ?? null
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-          // Don't consume ticket-based usage for invoice codes (they only change payment method)
-          discountUsageUnits = 0
-        } else if (isFreeNonInvoiceCode) {
-          // Non-invoice 100% off codes: order is free, ignore group discount
-          discountAmount = promoCodeDiscountAmount
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-        } else if (groupDiscountAmount > promoCodeDiscountAmount) {
-          // Group discount wins
-          discountAmount = groupDiscountAmount
-          appliedGroupDiscountId = groupDiscountRecord?.id ?? null
-          // Don't claim promo code usage since we're not using it
-          discountUsageUnits = 0
-          // Track if we ignored a valid promo code for a better group discount
-          if (promoCodeDiscountAmount > 0) {
-            promoCodeIgnoredForGroupDiscount = true
-          }
-        } else if (promoCodeDiscountAmount > 0) {
-          // Promo code wins (or tie goes to promo code)
-          discountAmount = promoCodeDiscountAmount
-          appliedDiscountCodeId = discountCodeRecord?.id ?? null
-        } else if (promoCodeError && groupDiscountAmount > 0) {
-          // Promo code was invalid but group discount applies - use group discount
-          discountAmount = groupDiscountAmount
-          appliedGroupDiscountId = groupDiscountRecord?.id ?? null
-          promoCodeIgnoredForGroupDiscount = true
-        } else if (promoCodeError) {
-          // Promo code was invalid and no group discount available - throw the error
-          throw new Error(promoCodeError)
-        }
-
-        const totalAmount = Number(Math.max(0, subtotal - discountAmount).toFixed(2))
-        const vatAmount = getIncludedVatFromVatInclusiveTotal(totalAmount, vatRate)
-
-        let status: 'PENDING' | 'PENDING_INVOICE' | 'PAID' = 'PENDING'
-        let paymentMethod: 'PAYPAL' | 'INVOICE' | 'FREE' = 'PAYPAL'
-
-        // A zero-total order is never invoiced — even when the applied discount
-        // code is INVOICE-typed (e.g. an INVOICE code used on a free ticket
-        // type, or stacked with a 100% group discount).
-        if (totalAmount === 0) {
-          status = 'PAID'
-          paymentMethod = 'FREE'
-        } else if (discountCodeRecord?.discountType === 'INVOICE') {
-          status = 'PAID'
-          paymentMethod = 'INVOICE'
-        } else if (discountCodeRecord?.discountType === 'FREE_TICKET') {
-          status = 'PAID'
-          paymentMethod = 'FREE'
-        }
-
-        const now = new Date()
-        // PENDING orders no longer auto-expire; organizers manage them manually
-        // via the dashboard (reminder flow + manual cancel).
-        const expiresAt = null
-
-        const order = await tx.order.create({
-          data: {
-            orderNumber: generateOrderNumber(),
-            userId: user?.id, // Associate with user if logged in
-            eventId: input.eventId,
-            discountCodeId: appliedDiscountCodeId,
-            groupDiscountId: appliedGroupDiscountId,
-            buyerFirstName: input.buyer.firstName,
-            buyerLastName: input.buyer.lastName,
-            buyerTitle: input.buyer.title,
-            buyerEmail: buyerEmail,
-            buyerOrganization: input.buyer.organization,
-            buyerAddress: input.buyer.address,
-            buyerCity: input.buyer.city,
-            buyerPostalCode: input.buyer.postalCode,
-            buyerCountry: input.buyer.country,
-            subtotal,
-            discountAmount,
-            totalAmount,
-            vatRate,
-            vatAmount,
-            currency: ticketTypes[0]?.currency ?? 'SEK',
-            status,
-            paymentMethod,
-            expiresAt,
-            paidAt: status === 'PAID' ? now : null,
-          },
-          include: {
-            items: true,
-            event: true,
-            tickets: true,
-          },
-        })
-
-        // Build a map of attendee data from the request, keyed by ticketTypeId
-        const attendeesByTicketType = new Map(
-          input.items
-            .filter((item) => item.attendees && item.attendees.length > 0)
-            .map((item) => [item.ticketTypeId, item.attendees!])
-        )
-
-        if (preparedOrder.items.length > 0) {
-          await tx.orderItem.createMany({
-            data: preparedOrder.items.map((item) => ({
-              orderId: order.id,
-              ticketTypeId: item.ticketTypeId,
-              quantity: item.quantity,
-              unitPrice: item.unitPrice,
-              totalPrice: item.totalPrice,
-              attendeeData: attendeesByTicketType.get(item.ticketTypeId) ?? undefined,
-            })),
-          })
-        }
-
-        if (status === 'PAID') {
-          for (const item of preparedOrder.items) {
-            await tx.ticketType.update({
-              where: { id: item.ticketTypeId },
-              data: {
-                soldCount: {
-                  increment: item.quantity,
-                },
-              },
-            })
-          }
-
-          const tickets = generateTicketCreateInput(
-            order.id,
-            preparedOrder.items.map((item) => ({
-              ...item,
-              attendees: attendeesByTicketType.get(item.ticketTypeId),
-            }))
-          )
-          if (tickets.length > 0) {
-            await tx.ticket.createMany({ data: tickets })
-          }
-        } else {
-          for (const item of preparedOrder.items) {
-            await tx.ticketType.update({
-              where: { id: item.ticketTypeId },
-              data: {
-                reservedCount: {
-                  increment: item.quantity,
-                },
-              },
-            })
-          }
-        }
-
-        // Only claim discount code usage if the promo code was actually applied (not when group discount won)
-        if (discountCodeRecord && appliedDiscountCodeId && discountUsageUnits > 0) {
-          const usageClaimed = await claimDiscountCodeUsage(
-            tx,
-            discountCodeRecord.id,
-            discountUsageUnits,
-            discountCodeRecord.maxUses
-          )
-
-          if (!usageClaimed) {
-            throw new Error('Discount code has no remaining uses for this quantity of tickets.')
-          }
-        }
-
-        const finalOrder = await tx.order.findUniqueOrThrow({
-          where: { id: order.id },
-          include: {
-            items: {
-              include: {
-                ticketType: {
-                  select: {
-                    name: true,
-                  },
-                },
-              },
-            },
-            tickets: true,
-            groupDiscount: {
-              select: {
-                minQuantity: true,
-                discountType: true,
-                discountValue: true,
-              },
-            },
-            discountCode: {
-              select: {
-                code: true,
-              },
-            },
-            event: {
-              select: {
-                id: true,
-                title: true,
-                startDate: true,
-                locationType: true,
-                venue: true,
-                city: true,
-                country: true,
-                onlineUrl: true,
-                organizer: {
-                  select: {
-                    user: {
-                      select: {
-                        email: true,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        })
-
-        // Return order with promo code warning if applicable
-        return {
-          order: finalOrder,
-          promoCodeWarning: promoCodeError && promoCodeIgnoredForGroupDiscount
-            ? `${promoCodeError}. A group discount was applied instead.`
-            : null,
-        }
-      },
-      {
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      }
-    )
-
-    const { order, promoCodeWarning } = createdOrder
+    const { order, promoCodeWarning } = await createOrder(input, { userId: user?.id })
 
     revalidateTag('event-analytics', 'max')
     revalidateTag('dashboard-analytics', 'max')
@@ -623,9 +60,7 @@ export async function POST(request: NextRequest) {
       const eventLocation =
         order.event.locationType === 'ONLINE'
           ? order.event.onlineUrl || 'Online event'
-          : [order.event.venue, order.event.city, order.event.country]
-              .filter(Boolean)
-              .join(', ')
+          : [order.event.venue, order.event.city, order.event.country].filter(Boolean).join(', ')
       const eventDate = formatDateTime(order.event.startDate)
       const buyerName = `${order.buyerFirstName} ${order.buyerLastName}`
 
@@ -647,7 +82,6 @@ export async function POST(request: NextRequest) {
         ticketCodes: order.tickets.map((t) => t.ticketCode),
       })
 
-      // Send each non-buyer attendee their own ticket email
       await sendAttendeeTicketEmailsForOrder({
         orderNumber: order.orderNumber,
         buyerEmail: order.buyerEmail,
@@ -660,7 +94,6 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // Notify organizer of new invoice order
     if (order.status === 'PENDING_INVOICE') {
       const organizerEmail = order.event.organizer?.user?.email
       if (organizerEmail) {
@@ -743,7 +176,10 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: error.message }, { status: 400 })
       }
 
-      if (error.message.includes('Minimum quantity') || error.message.includes('Maximum quantity')) {
+      if (
+        error.message.includes('Minimum quantity') ||
+        error.message.includes('Maximum quantity')
+      ) {
         return NextResponse.json({ error: error.message }, { status: 400 })
       }
     }

--- a/src/lib/orders/createOrder.ts
+++ b/src/lib/orders/createOrder.ts
@@ -1,0 +1,603 @@
+import { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { lockTicketTypes, prepareOrderItems, generateTicketCreateInput } from '@/lib/orders'
+import { claimDiscountCodeUsage, getDiscountUsageUnitsFromItems } from '@/lib/orders/discountUsage'
+import {
+  getCheckoutUnavailableReason,
+  getOrderErrorForCheckoutUnavailableReason,
+} from '@/lib/orders/checkoutAvailability'
+import {
+  calculateDiscountAmount,
+  decimalToNumber,
+  getApplicableTicketTypeIds,
+  getDiscountCodeRemainingTicketUses,
+  normalizeDiscountCode,
+} from '@/lib/tickets'
+import { generateOrderNumber, isTicketAvailable } from '@/lib/utils'
+import { getVatRateForCountryNameOrCode } from '@/lib/pricing/vatRates'
+import { getIncludedVatFromVatInclusiveTotal } from '@/lib/pricing/vat'
+import { type CreateOrderInput } from '@/lib/validations/order'
+
+// ── Shared types ────────────────────────────────────────────────────────────
+
+export type DiscountCodeWithLinks = Prisma.DiscountCodeGetPayload<{
+  include: { ticketTypes: true }
+}>
+
+export type GroupDiscountRecord = {
+  id: string
+  ticketTypeId: string | null
+  minQuantity: number
+  discountType: string
+  discountValue: Prisma.Decimal
+  isActive: boolean
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+export function calculateGroupDiscountAmount(
+  groupDiscount: GroupDiscountRecord,
+  items: { ticketTypeId: string; quantity: number; unitPrice: number; totalPrice: number }[],
+  vatRate: number
+): number {
+  const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
+  const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0)
+  const value = decimalToNumber(groupDiscount.discountValue)
+  // TIER_PRICE: organizer enters the exact per-ticket price (ex-VAT, matching
+  // ticketType.price convention) that applies when minQuantity is reached.
+  // Convert to VAT-inclusive so it matches the stored item.unitPrice.
+  const targetUnitInclVat = value * (1 + (vatRate ?? 0))
+
+  if (groupDiscount.ticketTypeId === null) {
+    // Global discount — check total quantity
+    if (totalQuantity < groupDiscount.minQuantity) return 0
+
+    if (groupDiscount.discountType === 'PERCENTAGE') {
+      return Number(Math.min(subtotal, (subtotal * value) / 100).toFixed(2))
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced = items.reduce(
+        (sum, item) => sum + Math.max(0, item.unitPrice - targetUnitInclVat) * item.quantity,
+        0
+      )
+      return Number(Math.min(subtotal, reduced).toFixed(2))
+    } else {
+      return Number(Math.min(subtotal, value).toFixed(2))
+    }
+  } else {
+    // Ticket-specific discount
+    const applicableItem = items.find((item) => item.ticketTypeId === groupDiscount.ticketTypeId)
+    if (!applicableItem || applicableItem.quantity < groupDiscount.minQuantity) return 0
+
+    if (groupDiscount.discountType === 'PERCENTAGE') {
+      return Number(
+        Math.min(applicableItem.totalPrice, (applicableItem.totalPrice * value) / 100).toFixed(2)
+      )
+    } else if (groupDiscount.discountType === 'TIER_PRICE') {
+      const reduced =
+        Math.max(0, applicableItem.unitPrice - targetUnitInclVat) * applicableItem.quantity
+      return Number(Math.min(applicableItem.totalPrice, reduced).toFixed(2))
+    } else {
+      return Number(Math.min(applicableItem.totalPrice, value).toFixed(2))
+    }
+  }
+}
+
+// ── createOrder ──────────────────────────────────────────────────────────────
+
+export interface CreateOrderOptions {
+  /** Associate the order with a logged-in user. Null for anonymous or manual orders. */
+  userId?: string | null
+  /**
+   * When true, applies the manual-order path:
+   *  - Skips event checkout-availability and per-ticket sales-window checks
+   *  - Skips discount-code minCartAmount validation
+   *  - Discount-code errors are silently ignored instead of thrown
+   *  - Order status is always PAID (free) or PENDING_INVOICE (invoiced); never PENDING/PAYPAL
+   */
+  isManualOrder?: boolean
+}
+
+// Keep the include shape in a const so the return type can be inferred precisely.
+const ORDER_RESULT_INCLUDE = {
+  items: {
+    include: {
+      ticketType: {
+        select: { name: true },
+      },
+    },
+  },
+  tickets: true,
+  groupDiscount: {
+    select: {
+      minQuantity: true,
+      discountType: true,
+      discountValue: true,
+    },
+  },
+  discountCode: {
+    select: { code: true },
+  },
+  event: {
+    select: {
+      id: true,
+      title: true,
+      startDate: true,
+      locationType: true,
+      venue: true,
+      city: true,
+      country: true,
+      onlineUrl: true,
+      organizer: {
+        select: {
+          user: {
+            select: { email: true },
+          },
+        },
+      },
+    },
+  },
+} as const
+
+export type CreatedOrder = Prisma.OrderGetPayload<{ include: typeof ORDER_RESULT_INCLUDE }>
+
+export interface CreateOrderResult {
+  order: CreatedOrder
+  /** Non-null when a valid promo code was present but a group discount was applied instead. */
+  promoCodeWarning: string | null
+}
+
+export async function createOrder(
+  input: CreateOrderInput,
+  opts: CreateOrderOptions = {}
+): Promise<CreateOrderResult> {
+  const { userId = null, isManualOrder = false } = opts
+  const buyerEmail = input.buyer.email.trim()
+
+  return prisma.$transaction(
+    async (tx) => {
+      // ── 1. Fetch event ──────────────────────────────────────────────────────
+      const event = await tx.event.findUnique({
+        where: { id: input.eventId },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          startDate: true,
+          endDate: true,
+          locationType: true,
+          venue: true,
+          city: true,
+          country: true,
+          onlineUrl: true,
+          status: true,
+          ticketTypes: {
+            where: { isVisible: true },
+            select: {
+              salesStartDate: true,
+              salesEndDate: true,
+              maxCapacity: true,
+              soldCount: true,
+              reservedCount: true,
+              isVisible: true,
+            },
+          },
+        },
+      })
+
+      if (!event) {
+        throw new Error('Event not found')
+      }
+
+      // ── 2. Checkout availability (public only) ──────────────────────────────
+      if (!isManualOrder) {
+        const checkoutUnavailableReason = getCheckoutUnavailableReason(event)
+        if (checkoutUnavailableReason) {
+          throw new Error(getOrderErrorForCheckoutUnavailableReason(checkoutUnavailableReason))
+        }
+      }
+
+      // ── 3. Lock and fetch ticket types ──────────────────────────────────────
+      const ticketTypeIds = Array.from(new Set(input.items.map((item) => item.ticketTypeId)))
+
+      await lockTicketTypes(tx, ticketTypeIds)
+
+      const ticketTypes = await tx.ticketType.findMany({
+        where: { eventId: input.eventId, id: { in: ticketTypeIds } },
+        select: {
+          id: true,
+          name: true,
+          price: true,
+          currency: true,
+          minPerOrder: true,
+          maxPerOrder: true,
+          maxCapacity: true,
+          soldCount: true,
+          reservedCount: true,
+          salesStartDate: true,
+          salesEndDate: true,
+        },
+      })
+
+      if (ticketTypes.length !== ticketTypeIds.length) {
+        throw new Error('One or more ticket types were not found for this event')
+      }
+
+      const vatRate = getVatRateForCountryNameOrCode(event.country ?? '')
+      const preparedOrder = prepareOrderItems(ticketTypes, input.items, { vatRate })
+
+      // ── 4. Per-ticket availability and capacity checks ──────────────────────
+      for (const item of preparedOrder.items) {
+        const ticketType = ticketTypes.find((t) => t.id === item.ticketTypeId)
+
+        if (!ticketType) {
+          throw new Error('Ticket type not found')
+        }
+
+        if (!isManualOrder) {
+          // Sales window + availability — public checkout only
+          const available = isTicketAvailable(
+            ticketType.salesStartDate,
+            ticketType.salesEndDate,
+            ticketType.maxCapacity,
+            ticketType.soldCount,
+            ticketType.reservedCount
+          )
+          if (!available) {
+            throw new Error(`${ticketType.name} is not currently available`)
+          }
+        }
+
+        if (ticketType.maxCapacity !== null) {
+          const remaining =
+            ticketType.maxCapacity - ticketType.soldCount - ticketType.reservedCount
+          if (remaining < item.quantity) {
+            throw new Error(
+              `${ticketType.name} does not have enough remaining capacity (${remaining} left)`
+            )
+          }
+        }
+      }
+
+      // ── 5. Discount code ────────────────────────────────────────────────────
+      let discountCodeRecord: DiscountCodeWithLinks | null = null
+      let discountUsageUnits = 0
+      let discountApplicableTicketTypeIds: string[] = []
+      let promoCodeDiscountAmount = 0
+      let promoCodeError: string | null = null
+
+      if (input.discountCode) {
+        const foundDiscountCode = await tx.discountCode.findUnique({
+          where: {
+            eventId_code: {
+              eventId: input.eventId,
+              code: normalizeDiscountCode(input.discountCode),
+            },
+          },
+          include: { ticketTypes: true },
+        })
+
+        let discountCodeApplicable = true
+
+        if (!foundDiscountCode) {
+          if (!isManualOrder) promoCodeError = 'Discount code not found'
+          discountCodeApplicable = false
+        } else {
+          const now = new Date()
+          const isValid =
+            foundDiscountCode.isActive &&
+            (!foundDiscountCode.validFrom || foundDiscountCode.validFrom <= now) &&
+            (!foundDiscountCode.validUntil || foundDiscountCode.validUntil > now)
+
+          if (!isValid) {
+            if (!isManualOrder)
+              promoCodeError = 'Discount code is inactive, expired, or fully used'
+            discountCodeApplicable = false
+          } else {
+            discountApplicableTicketTypeIds = getApplicableTicketTypeIds(foundDiscountCode)
+            const appliesToAll = discountApplicableTicketTypeIds.length === 0
+
+            if (discountApplicableTicketTypeIds.length > 0) {
+              const hasApplicableItem = preparedOrder.items.some((item) =>
+                discountApplicableTicketTypeIds.includes(item.ticketTypeId)
+              )
+              if (!hasApplicableItem) {
+                if (!isManualOrder)
+                  promoCodeError = 'Discount code does not apply to selected ticket types'
+                discountCodeApplicable = false
+              }
+            }
+
+            if (discountCodeApplicable) {
+              const applicableItems = preparedOrder.items.filter(
+                (item) =>
+                  appliesToAll || discountApplicableTicketTypeIds.includes(item.ticketTypeId)
+              )
+
+              // Compute discountable subtotal and usage units in one pass
+              let discountableSubtotal: number
+              if (foundDiscountCode.maxTicketsPerOrder !== null) {
+                const ticketPrices = applicableItems
+                  .flatMap((item) => Array(item.quantity).fill(item.unitPrice) as number[])
+                  .sort((a, b) => b - a)
+                const cappedPrices = ticketPrices.slice(0, foundDiscountCode.maxTicketsPerOrder)
+                discountableSubtotal = Number(
+                  cappedPrices.reduce((sum, p) => sum + p, 0).toFixed(2)
+                )
+                discountUsageUnits = cappedPrices.length
+              } else if (foundDiscountCode.applyToWholeOrder) {
+                discountableSubtotal = applicableItems.reduce(
+                  (sum, item) => Number((sum + item.totalPrice).toFixed(2)),
+                  0
+                )
+                discountUsageUnits = getDiscountUsageUnitsFromItems(applicableItems)
+              } else {
+                // Apply to the single most-expensive applicable ticket
+                const maxUnitPrice = Math.max(
+                  0,
+                  ...applicableItems.map((item) => item.unitPrice)
+                )
+                discountableSubtotal = maxUnitPrice
+                discountUsageUnits = 1
+              }
+
+              // Max uses check
+              if (foundDiscountCode.maxUses !== null) {
+                const remainingUses = getDiscountCodeRemainingTicketUses(foundDiscountCode) ?? 0
+                if (discountUsageUnits > remainingUses) {
+                  if (!isManualOrder) {
+                    promoCodeError =
+                      'Discount code has no remaining uses for this quantity of tickets.'
+                  }
+                  discountCodeApplicable = false
+                }
+              }
+
+              // minCartAmount check — public only
+              if (
+                discountCodeApplicable &&
+                !isManualOrder &&
+                foundDiscountCode.minCartAmount !== null
+              ) {
+                const minQuantity = decimalToNumber(foundDiscountCode.minCartAmount)
+                const totalApplicableQuantity = preparedOrder.items.reduce((sum, item) => {
+                  if (
+                    appliesToAll ||
+                    discountApplicableTicketTypeIds.includes(item.ticketTypeId)
+                  ) {
+                    return sum + item.quantity
+                  }
+                  return sum
+                }, 0)
+                if (totalApplicableQuantity < minQuantity) {
+                  promoCodeError = `At least ${minQuantity} ticket(s) of the applicable type are required for this discount code`
+                  discountCodeApplicable = false
+                }
+              }
+
+              if (discountCodeApplicable) {
+                discountCodeRecord = foundDiscountCode
+                promoCodeDiscountAmount = calculateDiscountAmount(
+                  discountableSubtotal,
+                  foundDiscountCode.discountType,
+                  decimalToNumber(foundDiscountCode.discountValue)
+                )
+              }
+            }
+          }
+        }
+      }
+
+      // ── 6. Group discount ───────────────────────────────────────────────────
+      let groupDiscountRecord: GroupDiscountRecord | null = null
+      let groupDiscountAmount = 0
+
+      if (input.groupDiscountId) {
+        const gd = await tx.groupDiscount.findUnique({
+          where: { id: input.groupDiscountId },
+          select: {
+            id: true,
+            eventId: true,
+            ticketTypeId: true,
+            minQuantity: true,
+            discountType: true,
+            discountValue: true,
+            isActive: true,
+          },
+        })
+        if (gd && gd.eventId === input.eventId && gd.isActive) {
+          groupDiscountRecord = gd
+          groupDiscountAmount = calculateGroupDiscountAmount(gd, preparedOrder.items, vatRate)
+        }
+      }
+
+      // ── 7. Discount arbitration ─────────────────────────────────────────────
+      const subtotal = preparedOrder.subtotal
+      let discountAmount = 0
+      let appliedGroupDiscountId: string | null = null
+      let appliedDiscountCodeId: string | null = null
+      let promoCodeIgnoredForGroupDiscount = false
+
+      const isInvoiceCode = discountCodeRecord?.discountType === 'INVOICE'
+      const isFreeNonInvoiceCode =
+        discountCodeRecord &&
+        !isInvoiceCode &&
+        (discountCodeRecord.discountType === 'FREE_TICKET' ||
+          (discountCodeRecord.discountType === 'PERCENTAGE' &&
+            decimalToNumber(discountCodeRecord.discountValue) >= 100))
+
+      if (isInvoiceCode) {
+        // Invoice codes stack with group discounts: group discount for price, invoice for payment method
+        discountAmount = groupDiscountAmount
+        appliedGroupDiscountId = groupDiscountRecord?.id ?? null
+        appliedDiscountCodeId = discountCodeRecord?.id ?? null
+        // Don't consume ticket-based usage for invoice codes (they only change payment method)
+        discountUsageUnits = 0
+      } else if (isFreeNonInvoiceCode) {
+        // Non-invoice 100% off codes: order is free, ignore group discount
+        discountAmount = promoCodeDiscountAmount
+        appliedDiscountCodeId = discountCodeRecord?.id ?? null
+      } else if (groupDiscountAmount > promoCodeDiscountAmount) {
+        // Group discount wins
+        discountAmount = groupDiscountAmount
+        appliedGroupDiscountId = groupDiscountRecord?.id ?? null
+        discountUsageUnits = 0
+        if (promoCodeDiscountAmount > 0) {
+          promoCodeIgnoredForGroupDiscount = true
+        }
+      } else if (promoCodeDiscountAmount > 0) {
+        // Promo code wins (or tie goes to promo code)
+        discountAmount = promoCodeDiscountAmount
+        appliedDiscountCodeId = discountCodeRecord?.id ?? null
+      } else if (promoCodeError && groupDiscountAmount > 0) {
+        // Promo code was invalid but group discount applies — use group discount silently
+        discountAmount = groupDiscountAmount
+        appliedGroupDiscountId = groupDiscountRecord?.id ?? null
+        promoCodeIgnoredForGroupDiscount = true
+      } else if (promoCodeError) {
+        // Promo code was invalid and no group discount available — surface the error
+        // (isManualOrder never sets promoCodeError so this branch is public-only)
+        throw new Error(promoCodeError)
+      }
+
+      const totalAmount = Number(Math.max(0, subtotal - discountAmount).toFixed(2))
+      const vatAmount = getIncludedVatFromVatInclusiveTotal(totalAmount, vatRate)
+
+      // ── 8. Status and payment method ────────────────────────────────────────
+      let status: 'PENDING' | 'PENDING_INVOICE' | 'PAID'
+      let paymentMethod: 'PAYPAL' | 'INVOICE' | 'FREE'
+
+      if (isManualOrder) {
+        // Manual orders: free → PAID/FREE, otherwise always invoice
+        // A zero-total order is never invoiced.
+        status = totalAmount === 0 ? 'PAID' : 'PENDING_INVOICE'
+        paymentMethod = totalAmount === 0 ? 'FREE' : 'INVOICE'
+      } else {
+        // Public checkout: default to Stripe pending
+        status = 'PENDING'
+        paymentMethod = 'PAYPAL'
+        // A zero-total order is never invoiced — even when the applied discount
+        // code is INVOICE-typed (e.g. stacked with a 100% group discount).
+        if (totalAmount === 0) {
+          status = 'PAID'
+          paymentMethod = 'FREE'
+        } else if (discountCodeRecord?.discountType === 'INVOICE') {
+          status = 'PAID'
+          paymentMethod = 'INVOICE'
+        } else if (discountCodeRecord?.discountType === 'FREE_TICKET') {
+          status = 'PAID'
+          paymentMethod = 'FREE'
+        }
+      }
+
+      const now = new Date()
+      // PENDING orders no longer auto-expire; organizers manage them manually
+      // via the dashboard (reminder flow + manual cancel).
+      const expiresAt = null
+
+      // ── 9. Create order record ──────────────────────────────────────────────
+      const order = await tx.order.create({
+        data: {
+          orderNumber: generateOrderNumber(),
+          userId,
+          eventId: input.eventId,
+          discountCodeId: appliedDiscountCodeId,
+          groupDiscountId: appliedGroupDiscountId,
+          buyerFirstName: input.buyer.firstName,
+          buyerLastName: input.buyer.lastName,
+          buyerTitle: input.buyer.title,
+          buyerEmail,
+          buyerOrganization: input.buyer.organization,
+          buyerAddress: input.buyer.address,
+          buyerCity: input.buyer.city,
+          buyerPostalCode: input.buyer.postalCode,
+          buyerCountry: input.buyer.country,
+          subtotal,
+          discountAmount,
+          totalAmount,
+          vatRate,
+          vatAmount,
+          currency: ticketTypes[0]?.currency ?? 'SEK',
+          status,
+          paymentMethod,
+          expiresAt,
+          paidAt: status === 'PAID' ? now : null,
+        },
+      })
+
+      // ── 10. Order items ─────────────────────────────────────────────────────
+      const attendeesByTicketType = new Map(
+        input.items
+          .filter((item) => item.attendees && item.attendees.length > 0)
+          .map((item) => [item.ticketTypeId, item.attendees!])
+      )
+
+      if (preparedOrder.items.length > 0) {
+        await tx.orderItem.createMany({
+          data: preparedOrder.items.map((item) => ({
+            orderId: order.id,
+            ticketTypeId: item.ticketTypeId,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            totalPrice: item.totalPrice,
+            attendeeData: attendeesByTicketType.get(item.ticketTypeId) ?? undefined,
+          })),
+        })
+      }
+
+      // ── 11. Tickets / reservations ──────────────────────────────────────────
+      if (status === 'PAID') {
+        for (const item of preparedOrder.items) {
+          await tx.ticketType.update({
+            where: { id: item.ticketTypeId },
+            data: { soldCount: { increment: item.quantity } },
+          })
+        }
+        const tickets = generateTicketCreateInput(
+          order.id,
+          preparedOrder.items.map((item) => ({
+            ...item,
+            attendees: attendeesByTicketType.get(item.ticketTypeId),
+          }))
+        )
+        if (tickets.length > 0) {
+          await tx.ticket.createMany({ data: tickets })
+        }
+      } else {
+        for (const item of preparedOrder.items) {
+          await tx.ticketType.update({
+            where: { id: item.ticketTypeId },
+            data: { reservedCount: { increment: item.quantity } },
+          })
+        }
+      }
+
+      // ── 12. Claim discount code usage ───────────────────────────────────────
+      if (discountCodeRecord && appliedDiscountCodeId && discountUsageUnits > 0) {
+        const usageClaimed = await claimDiscountCodeUsage(
+          tx,
+          discountCodeRecord.id,
+          discountUsageUnits,
+          discountCodeRecord.maxUses
+        )
+        if (!usageClaimed) {
+          throw new Error('Discount code has no remaining uses for this quantity of tickets.')
+        }
+      }
+
+      // ── 13. Final read with full includes ───────────────────────────────────
+      const finalOrder = await tx.order.findUniqueOrThrow({
+        where: { id: order.id },
+        include: ORDER_RESULT_INCLUDE,
+      })
+
+      return {
+        order: finalOrder,
+        promoCodeWarning:
+          promoCodeError && promoCodeIgnoredForGroupDiscount
+            ? `${promoCodeError}. A group discount was applied instead.`
+            : null,
+      }
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+  )
+}


### PR DESCRIPTION
### Summary                                                                               
                                                                                        
  Order creation logic was duplicated between the public checkout and manual order        routes, meaning any change to pricing or discount rules had to be made in two places.
 
                                                                   
### Old behavior

  orders/route.ts and orders/manual/route.ts each contained their own copy of the full
  order creation logic, including a duplicated calculateGroupDiscountAmount function.


 ###  New behavior

  Both routes delegate to a single shared createOrder function. The public and manual
  paths are distinguished by an isManualOrder flag, which controls things like
  availability checks and order status.

 
### Changes

  - Extracted shared logic into src/lib/orders/createOrder.ts
  - Both routes now call createOrder with their respective options
  - calculateGroupDiscountAmount exists in exactly one place
  - Added tests covering both entry points and the group discount calculation

---

### Tasks
 
 **Group discount calculation**
- [x] 1. Below the minimum quantity — if the order doesn't have enough tickets to qualify, no discount is given.
- [x]   2. Percentage discount — a percentage off the order total is calculated correctly.
- [x]   4. Fixed amount discount — a fixed amount is taken off the total.
- [x]   5. Fixed discount larger than the total — the discount is capped so the order never goes negative.
- [x]   6. Per-ticket percentage discount, minimum met — the discount applies only to the qualifying ticket type

 **Public checkout (customer placing an order online)**
- [x]  8. Paid order — a normal order is created 
- [x]   9. Free order — when the total is zero, the order is immediately marked as completed.
- [x]   10. Event not accepting orders — if the event is closed for sales, the order is rejected before anything is saved.
- [x]   12. Invalid discount code — if the customer enters a code that doesn't exist, the order is rejected with an error.

**Manual order (organizer creating an order from the dashboard)**
- [ ]  13. Paid order — a non-free manual order is created as a pending invoice, not sent to
  payment. //While testing, an order is created but an email is not automatically sent to the user. Unsure if this is something we want
- [x] 14. Free order — when the total is zero, the order is immediately marked as completed,   same as public.